### PR TITLE
Fix: Grant packages write permission to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The previous workflow was failing with a permission error when trying to publish the Docker image to the GitHub Container Registry. This was because the GITHUB_TOKEN did not have the required 'packages: write' permission.

This commit adds the necessary permissions to the 'build-and-publish' job in the .github/workflows/docker-publish.yml file to allow it to successfully push images to ghcr.io.