### PR TITLE
feat: Implement functionality to undo a completed task

### DIFF
--- a/app/templates/workflow_instance.html
+++ b/app/templates/workflow_instance.html
@@ -18,6 +18,10 @@
                             <form action="/task-instances/{{ task.id }}/complete" method="post" style="display:inline; margin-left:10px;">
                                 <button type="submit" class="action-button submit">Mark Complete</button>
                             </form>
+                        {% elif task.status == "completed" %}
+                            <form action="/task-instances/{{ task.id }}/undo-complete" method="post" style="display:inline; margin-left:10px;">
+                                <button type="submit" class="button is-info is-small">Undo Complete</button>
+                            </form>
                         {% endif %}
                     </li>
                 {% endfor %}


### PR DESCRIPTION
This commit introduces the ability for you to undo the completion of a task.

Key changes include:
- Added an `undo_complete_task` method to `WorkflowService` to revert a task's status from 'completed' to 'pending'. This method also updates the parent workflow's status from 'completed' to 'active' if necessary.
- Introduced a new API endpoint `POST /task-instances/{task_id}/undo-complete` that exposes this new service logic.
- Updated the workflow instance page (`workflow_instance.html`) to display an "Undo Complete" button for tasks that are currently marked as 'completed'.
- Added comprehensive unit tests for the `undo_complete_task` service method, covering various scenarios including success, task not found, task not completed, unauthorized access, and workflow status updates.