### PR TITLE
Feat: Add unarchive functionality for workflow instances

### DIFF
--- a/app/core/html_renderer.py
+++ b/app/core/html_renderer.py
@@ -1,12 +1,15 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Any
-from fastapi.templating import Jinja2Templates
+
 from fastapi.requests import Request
+from fastapi.templating import Jinja2Templates
+
 
 class HtmlRendererInterface(ABC):
     @abstractmethod
     async def render(self, template_name: str, request: Request, context: Dict[str, Any]) -> str:
         pass
+
 
 class Jinja2HtmlRenderer(HtmlRendererInterface):
     def __init__(self, templates: Jinja2Templates):

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,14 +1,16 @@
 from typing import Annotated, Dict, Any
-from fastapi import Depends, HTTPException, status, Request
-from fastapi.security import OAuth2PasswordBearer
-from pydantic import BaseModel
+
 import jwt
 import requests
-from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM, KEYCLOAK_API_CLIENT_ID
+from fastapi import Depends, HTTPException, status, Request
+from fastapi.security import OAuth2PasswordBearer
 from jwt.algorithms import RSAAlgorithm
+from pydantic import BaseModel
 
+from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
+
 
 class AuthenticatedUser(BaseModel):
     user_id: str
@@ -16,6 +18,7 @@ class AuthenticatedUser(BaseModel):
     email: str | None = None
     full_name: str | None = None
     disabled: bool | None = False
+
 
 # Temporarily comment out lru_cache to rule out stale cached keys
 # @lru_cache(maxsize=1) 
@@ -27,38 +30,40 @@ def get_keycloak_public_keys() -> Dict[str, Any]:
     jwks_data = response.json()
     return jwks_data
 
-async def get_current_user(request: Request, token: Annotated[str | None, Depends(oauth2_scheme)] = None) -> AuthenticatedUser:
+
+async def get_current_user(request: Request,
+                           token: Annotated[str | None, Depends(oauth2_scheme)] = None) -> AuthenticatedUser:
     """Extract user information from Keycloak JWT token."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid authentication credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    
+
     if token is None:
         token = request.cookies.get("access_token", "")
-    
+
     if not token:
         if request.url.path.startswith("/api"):
-            raise credentials_exception # Defined earlier, raises 401
+            raise credentials_exception  # Defined earlier, raises 401
         else:
             # Redirect to login page for non-API routes
             from fastapi.responses import RedirectResponse
             original_url = str(request.url)
             login_url = f"/login?redirect={original_url}"
             return RedirectResponse(url=login_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
-        
+
     try:
         jwks = get_keycloak_public_keys()
         keys_from_jwks = jwks.get('keys', [])
-        
+
         if not keys_from_jwks:
             raise credentials_exception
 
         decoded_token_payload = None
         last_exception = None
-        
-        for key_data in keys_from_jwks: 
+
+        for key_data in keys_from_jwks:
             try:
                 public_key = RSAAlgorithm.from_jwk(key_data)
                 expected_issuer = f"{KEYCLOAK_SERVER_URL}realms/{KEYCLOAK_REALM}"
@@ -75,38 +80,40 @@ async def get_current_user(request: Request, token: Annotated[str | None, Depend
                 raise credentials_exception from e
             except jwt.InvalidTokenError as e:
                 last_exception = e
-                continue 
-            except Exception as e: 
+                continue
+            except Exception as e:
                 last_exception = e
                 continue
-                
+
         if decoded_token_payload is None:
             if last_exception:
                 raise credentials_exception from last_exception
             else:
                 raise credentials_exception
-            
+
         user_id = decoded_token_payload.get("sub", "")
         username = decoded_token_payload.get("preferred_username", "")
         email = decoded_token_payload.get("email", None)
         full_name = decoded_token_payload.get("name", None)
-        
+
         if not user_id or not username:
             raise credentials_exception
-            
+
         return AuthenticatedUser(
             user_id=user_id,
             username=username,
             email=email,
             full_name=full_name,
-            disabled=False 
+            disabled=False
         )
-    except HTTPException as e: 
+    except HTTPException as e:
         raise e
-    except Exception as e: 
+    except Exception as e:
         raise credentials_exception from e
 
-async def get_current_active_user(current_user: Annotated[AuthenticatedUser, Depends(get_current_user)]) -> AuthenticatedUser:
+
+async def get_current_active_user(
+        current_user: Annotated[AuthenticatedUser, Depends(get_current_user)]) -> AuthenticatedUser:
     """Check if the current user is active. Keycloak handles this before token issuance."""
     # If current_user is a RedirectResponse, return it immediately
     if not isinstance(current_user, AuthenticatedUser):

--- a/app/database.py
+++ b/app/database.py
@@ -1,11 +1,12 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.config import DATABASE_URL
-from app.db_models import Base
 
 # SQLAlchemy setup
 engine = create_engine(DATABASE_URL, echo=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
 
 def get_db():
     db = SessionLocal()

--- a/app/db_models/__init__.py
+++ b/app/db_models/__init__.py
@@ -1,4 +1,4 @@
 from app.db_models.base import Base
-from app.db_models.workflow import WorkflowDefinition, WorkflowInstance
-from app.db_models.task import TaskInstance
 from app.db_models.enums import WorkflowStatus, TaskStatus
+from app.db_models.task import TaskInstance
+from app.db_models.workflow import WorkflowDefinition, WorkflowInstance

--- a/app/db_models/enums.py
+++ b/app/db_models/enums.py
@@ -1,9 +1,11 @@
 from enum import Enum
 
+
 class WorkflowStatus(str, Enum):
     active = "active"
     completed = "completed"
     archived = "archived"
+
 
 class TaskStatus(str, Enum):
     pending = "pending"

--- a/app/db_models/task.py
+++ b/app/db_models/task.py
@@ -1,9 +1,11 @@
 import uuid
+
 from sqlalchemy import Column, String, Integer, Enum as SQLAlchemyEnum, ForeignKey
 from sqlalchemy.orm import relationship
 
 from app.db_models.base import Base
 from app.db_models.enums import TaskStatus
+
 
 class TaskInstance(Base):
     __tablename__ = "task_instances"

--- a/app/db_models/workflow.py
+++ b/app/db_models/workflow.py
@@ -1,11 +1,12 @@
 import uuid
+
 from sqlalchemy import Column, String, Text, Date, Enum as SQLAlchemyEnum, ForeignKey
-from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
-from typing import List
+from sqlalchemy.orm import relationship
 
 from app.db_models.base import Base
 from app.db_models.enums import WorkflowStatus
+
 
 class WorkflowDefinition(Base):
     __tablename__ = "workflow_definitions"
@@ -16,6 +17,7 @@ class WorkflowDefinition(Base):
     task_names = Column(JSONB, nullable=False, default=lambda: [])  # Stored as JSONB for proper list handling
 
     instances = relationship("WorkflowInstance", back_populates="definition")
+
 
 class WorkflowInstance(Base):
     __tablename__ = "workflow_instances"

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -4,22 +4,28 @@ from fastapi import Depends
 
 from app.core.html_renderer import HtmlRendererInterface, Jinja2HtmlRenderer
 from app.database import get_db
-from app.repository import WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository, PostgreSQLWorkflowRepository
+from app.repository import WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository, \
+    PostgreSQLWorkflowRepository
 from app.services import WorkflowService
 from app.templating import get_templates
+
 
 # Dependency for HTML Renderer
 def get_html_renderer() -> HtmlRendererInterface:
     return Jinja2HtmlRenderer(get_templates())
 
+
 # --- Dependencies ---
-def get_workflow_repository(db=Depends(get_db)) -> Tuple[WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository]:
+def get_workflow_repository(db=Depends(get_db)) -> Tuple[
+    WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository]:
     """Provides instances of the repository interfaces."""
     repo = PostgreSQLWorkflowRepository(db)
     return repo, repo, repo
 
+
 def get_workflow_service(
-    repos: Tuple[WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository] = Depends(get_workflow_repository)
+        repos: Tuple[WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository] = Depends(
+            get_workflow_repository)
 ) -> WorkflowService:
     """Provides an instance of the WorkflowService, injecting the repositories."""
     definition_repo, instance_repo, task_repo = repos

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from app.templating import get_templates
 from app.routers import root, workflow_definitions, workflow_instances, tasks, auth, user_workflows, api
 
 app = FastAPI(

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from app.db_models.enums import WorkflowStatus, TaskStatus
 
+
 class WorkflowDefinition(BaseModel):
     id: str = Field(default_factory=lambda: "def_" + str(uuid.uuid4())[:8])
     name: str
@@ -22,6 +23,7 @@ class WorkflowDefinition(BaseModel):
     @classmethod
     def from_dict(cls, data: dict):
         return cls(**data)
+
 
 class TaskInstance(BaseModel):
     id: str = Field(default_factory=lambda: "task_" + str(uuid.uuid4())[:8])
@@ -39,6 +41,7 @@ class TaskInstance(BaseModel):
     @classmethod
     def from_dict(cls, data: dict):
         return cls(**data)
+
 
 class WorkflowInstance(BaseModel):
     id: str = Field(default_factory=lambda: "wf_" + str(uuid.uuid4())[:8])

--- a/app/repository.py
+++ b/app/repository.py
@@ -1,12 +1,12 @@
 # repository.py
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict
 from datetime import date as DateObject
+from typing import List, Optional, Dict
 
-from app.models import WorkflowDefinition, WorkflowInstance, TaskInstance
 from app.db_models.enums import WorkflowStatus
-from app.db_models.workflow import WorkflowDefinition as WorkflowDefinitionORM, WorkflowInstance as WorkflowInstanceORM
 from app.db_models.task import TaskInstance as TaskInstanceORM
+from app.db_models.workflow import WorkflowDefinition as WorkflowDefinitionORM, WorkflowInstance as WorkflowInstanceORM
+from app.models import WorkflowDefinition, WorkflowInstance, TaskInstance
 
 # In-memory stores
 _workflow_definitions_db: Dict[str, WorkflowDefinition] = {}
@@ -28,7 +28,8 @@ class WorkflowDefinitionRepository(ABC):
         pass
 
     @abstractmethod
-    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str], task_names: List[str]) -> Optional[WorkflowDefinition]:
+    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str],
+                                         task_names: List[str]) -> Optional[WorkflowDefinition]:
         pass
 
     @abstractmethod
@@ -46,7 +47,8 @@ class WorkflowInstanceRepository(ABC):
         pass
 
     @abstractmethod
-    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[WorkflowInstance]:
+    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[
+        WorkflowInstance]:
         pass
 
     @abstractmethod
@@ -77,17 +79,21 @@ class DefinitionNotFoundError(Exception):
     """Raised when a workflow definition is not found."""
     pass
 
+
 class DefinitionInUseError(ValueError):
     """Raised when a workflow definition cannot be deleted because it's in use."""
     pass
+
 
 class InstanceNotFoundError(Exception):
     """Raised when a workflow instance is not found."""
     pass
 
+
 class TaskNotFoundError(Exception):
     """Raised when a task instance is not found."""
     pass
+
 
 class PostgreSQLWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository):
     def __init__(self, db_session):
@@ -115,7 +121,8 @@ class PostgreSQLWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanc
         self.db_session.refresh(instance)
         return WorkflowInstance.model_validate(instance, from_attributes=True)
 
-    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[WorkflowInstance]:
+    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[
+        WorkflowInstance]:
         instance = self.db_session.query(WorkflowInstanceORM).filter(WorkflowInstanceORM.id == instance_id).first()
         if instance:
             for key, value in instance_update.model_dump(mode='json').items():
@@ -145,10 +152,12 @@ class PostgreSQLWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanc
         return None
 
     async def get_tasks_for_workflow_instance(self, instance_id: str) -> List[TaskInstance]:
-        tasks = self.db_session.query(TaskInstanceORM).filter(TaskInstanceORM.workflow_instance_id == instance_id).order_by(TaskInstanceORM.order).all()
+        tasks = self.db_session.query(TaskInstanceORM).filter(
+            TaskInstanceORM.workflow_instance_id == instance_id).order_by(TaskInstanceORM.order).all()
         return [TaskInstance.model_validate(task, from_attributes=True) for task in tasks]
 
-    async def list_workflow_instances_by_user(self, user_id: str, created_at_date: Optional[DateObject] = None, status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
+    async def list_workflow_instances_by_user(self, user_id: str, created_at_date: Optional[DateObject] = None,
+                                              status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
         query = self.db_session.query(WorkflowInstanceORM).filter(WorkflowInstanceORM.user_id == user_id)
         if created_at_date:
             query = query.filter(WorkflowInstanceORM.created_at == created_at_date)
@@ -164,8 +173,10 @@ class PostgreSQLWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanc
         self.db_session.refresh(definition)
         return WorkflowDefinition.model_validate(definition, from_attributes=True)
 
-    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str], task_names: List[str]) -> Optional[WorkflowDefinition]:
-        db_definition = self.db_session.query(WorkflowDefinitionORM).filter(WorkflowDefinitionORM.id == definition_id).first()
+    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str],
+                                         task_names: List[str]) -> Optional[WorkflowDefinition]:
+        db_definition = self.db_session.query(WorkflowDefinitionORM).filter(
+            WorkflowDefinitionORM.id == definition_id).first()
         if db_definition:
             db_definition.name = name
             db_definition.description = description
@@ -176,14 +187,17 @@ class PostgreSQLWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanc
         return None
 
     async def delete_workflow_definition(self, definition_id: str) -> None:
-        db_definition = self.db_session.query(WorkflowDefinitionORM).filter(WorkflowDefinitionORM.id == definition_id).first()
+        db_definition = self.db_session.query(WorkflowDefinitionORM).filter(
+            WorkflowDefinitionORM.id == definition_id).first()
         if not db_definition:
             raise DefinitionNotFoundError(f"Workflow Definition with ID '{definition_id}' not found.")
-        
-        linked_instances_count = self.db_session.query(WorkflowInstanceORM).filter(WorkflowInstanceORM.workflow_definition_id == definition_id).count()
+
+        linked_instances_count = self.db_session.query(WorkflowInstanceORM).filter(
+            WorkflowInstanceORM.workflow_definition_id == definition_id).count()
         if linked_instances_count > 0:
-            raise DefinitionInUseError(f"Cannot delete definition: It is currently used by {linked_instances_count} workflow instance(s).")
-            
+            raise DefinitionInUseError(
+                f"Cannot delete definition: It is currently used by {linked_instances_count} workflow instance(s).")
+
         self.db_session.delete(db_definition)
         self.db_session.commit()
 
@@ -228,7 +242,8 @@ class InMemoryWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanceR
         _workflow_instances_db[new_instance.id] = new_instance
         return new_instance.model_copy(deep=True)
 
-    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[WorkflowInstance]:
+    async def update_workflow_instance(self, instance_id: str, instance_update: WorkflowInstance) -> Optional[
+        WorkflowInstance]:
         if instance_id in _workflow_instances_db:
             _workflow_instances_db[instance_id] = instance_update.model_copy(deep=True)
             return _workflow_instances_db[instance_id].model_copy(deep=True)
@@ -256,7 +271,8 @@ class InMemoryWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanceR
         ]
         return sorted(tasks, key=lambda t: t.order)
 
-    async def list_workflow_instances_by_user(self, user_id: str, created_at_date: Optional[DateObject] = None, status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
+    async def list_workflow_instances_by_user(self, user_id: str, created_at_date: Optional[DateObject] = None,
+                                              status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
         instances = [
             instance.model_copy(deep=True) for instance in _workflow_instances_db.values()
             if instance.user_id == user_id
@@ -272,7 +288,8 @@ class InMemoryWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanceR
         _workflow_definitions_db[new_definition.id] = new_definition
         return new_definition.model_copy(deep=True)
 
-    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str], task_names: List[str]) -> Optional[WorkflowDefinition]:
+    async def update_workflow_definition(self, definition_id: str, name: str, description: Optional[str],
+                                         task_names: List[str]) -> Optional[WorkflowDefinition]:
         if definition_id in _workflow_definitions_db:
             updated_definition = WorkflowDefinition(
                 id=definition_id,
@@ -287,9 +304,11 @@ class InMemoryWorkflowRepository(WorkflowDefinitionRepository, WorkflowInstanceR
     async def delete_workflow_definition(self, definition_id: str) -> None:
         if definition_id not in _workflow_definitions_db:
             raise DefinitionNotFoundError(f"Workflow Definition with ID '{definition_id}' not found.")
-            
-        linked_instances = any(instance.workflow_definition_id == definition_id for instance in _workflow_instances_db.values())
+
+        linked_instances = any(
+            instance.workflow_definition_id == definition_id for instance in _workflow_instances_db.values())
         if linked_instances:
-            raise DefinitionInUseError("Cannot delete definition: It is currently used by one or more workflow instances.")
-            
+            raise DefinitionInUseError(
+                "Cannot delete definition: It is currently used by one or more workflow instances.")
+
         del _workflow_definitions_db[definition_id]

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -1,16 +1,20 @@
-from fastapi import APIRouter, Depends, HTTPException, status
 from typing import List, Dict, Any
-from app.services import WorkflowService
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.core.security import AuthenticatedUser, get_current_active_user
 from app.dependencies import get_workflow_service
 from app.models import WorkflowDefinition, WorkflowInstance, TaskInstance
-from app.core.security import AuthenticatedUser, get_current_active_user
+from app.services import WorkflowService
 
 router = APIRouter(prefix="/api", tags=["api"])
+
 
 @router.get("/healthz", status_code=status.HTTP_200_OK)
 async def healthcheck():
     """API endpoint for health check."""
     return {"status": "ok"}
+
 
 @router.get("/workflow-definitions", response_model=List[WorkflowDefinition])
 async def list_workflow_definitions(
@@ -18,6 +22,7 @@ async def list_workflow_definitions(
 ):
     """API endpoint to list all workflow definitions as JSON."""
     return await service.list_workflow_definitions()
+
 
 @router.post("/workflow-definitions", response_model=WorkflowDefinition, status_code=status.HTTP_201_CREATED)
 async def create_workflow_definition(
@@ -34,6 +39,7 @@ async def create_workflow_definition(
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
 
 @router.put("/workflow-definitions/{definition_id}", response_model=WorkflowDefinition)
 async def update_workflow_definition(
@@ -53,6 +59,7 @@ async def update_workflow_definition(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Definition not found")
     return updated
 
+
 @router.delete("/workflow-definitions/{definition_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_workflow_definition(
         definition_id: str,
@@ -67,6 +74,7 @@ async def delete_workflow_definition(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
+
 @router.post("/workflow-instances", response_model=WorkflowInstance, status_code=status.HTTP_201_CREATED)
 async def create_workflow_instance(
         definition_id: dict,  # Expecting a dict with 'definition_id' key for form data compatibility
@@ -78,6 +86,7 @@ async def create_workflow_instance(
     if not instance:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to create instance")
     return instance
+
 
 @router.get("/workflow-instances/{instance_id}", response_model=Dict[str, Any])
 async def get_workflow_instance(
@@ -91,6 +100,7 @@ async def get_workflow_instance(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found or access denied")
     return details
 
+
 @router.post("/task-instances/{task_id}/complete", response_model=TaskInstance)
 async def complete_task(
         task_id: str,
@@ -102,6 +112,7 @@ async def complete_task(
     if not task:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Task not found or already completed")
     return task
+
 
 @router.get("/my-workflows", response_model=Dict[str, List[WorkflowInstance]])
 async def list_user_workflows(

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,12 +1,16 @@
-from fastapi import APIRouter, Request, HTTPException, Depends
-from fastapi.responses import RedirectResponse
-from fastapi import status
-import requests
 import os
-from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM, KEYCLOAK_API_CLIENT_ID, KEYCLOAK_API_CLIENT_SECRET, KEYCLOAK_REDIRECT_URI
 from urllib.parse import quote_plus
 
+import requests
+from fastapi import APIRouter, Request, HTTPException
+from fastapi import status
+from fastapi.responses import RedirectResponse
+
+from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM, KEYCLOAK_API_CLIENT_ID, KEYCLOAK_API_CLIENT_SECRET, \
+    KEYCLOAK_REDIRECT_URI
+
 router = APIRouter(tags=["auth"])
+
 
 @router.get("/login", response_class=RedirectResponse)
 async def redirect_to_keycloak_login(request: Request, redirect: str = None):
@@ -18,6 +22,7 @@ async def redirect_to_keycloak_login(request: Request, redirect: str = None):
         f"&state={original_url}"
     )
     return RedirectResponse(url=login_url)
+
 
 @router.get("/callback", response_class=RedirectResponse)
 async def handle_keycloak_callback(code: str, state: str = None):
@@ -56,6 +61,7 @@ async def handle_keycloak_callback(code: str, state: str = None):
 
     return redirect_response
 
+
 @router.post("/token")
 async def token_placeholder():
     """Placeholder for token endpoint - actual authentication handled by Keycloak."""
@@ -64,10 +70,12 @@ async def token_placeholder():
         detail="Authentication handled by Keycloak. Use /login endpoint or configure client to use Keycloak directly."
     )
 
+
 @router.get("/logout", response_class=RedirectResponse)
 async def logout():
     """Logout user by clearing cookies and redirecting to Keycloak logout."""
-    post_logout_redirect_to_app = os.getenv("KEYCLOAK_POST_LOGOUT_REDIRECT_URI", f"{KEYCLOAK_REDIRECT_URI.split('/callback')[0]}/login")
+    post_logout_redirect_to_app = os.getenv("KEYCLOAK_POST_LOGOUT_REDIRECT_URI",
+                                            f"{KEYCLOAK_REDIRECT_URI.split('/callback')[0]}/login")
     encoded_post_logout_redirect = quote_plus(post_logout_redirect_to_app)
 
     keycloak_logout_url = (

--- a/app/routers/root.py
+++ b/app/routers/root.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
+
+from app.core.html_renderer import HtmlRendererInterface
 from app.core.security import AuthenticatedUser, get_current_user
 from app.dependencies import get_html_renderer
-from app.core.html_renderer import HtmlRendererInterface
 
 router = APIRouter()
+
 
 @router.get("/", response_class=HTMLResponse)
 async def read_root(

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,13 +1,15 @@
 from fastapi import APIRouter, Request, Depends
-from fastapi.responses import RedirectResponse
 from fastapi import status
-from app.services import WorkflowService
+from fastapi.responses import RedirectResponse
+
 from app.core.html_renderer import HtmlRendererInterface
 from app.core.security import AuthenticatedUser, get_current_active_user
 from app.dependencies import get_workflow_service, get_html_renderer
+from app.services import WorkflowService
 from app.utils import create_message_page
 
 router = APIRouter(prefix="/task-instances", tags=["tasks"])
+
 
 @router.post("/{task_id}/complete", response_class=RedirectResponse)
 async def complete_task_handler(

--- a/app/routers/user_workflows.py
+++ b/app/routers/user_workflows.py
@@ -1,15 +1,17 @@
+from datetime import date
 from typing import Optional
 
 from fastapi import APIRouter, Request, Depends, Query
 from fastapi.responses import HTMLResponse, RedirectResponse
-from datetime import date
-from app.services import WorkflowService
-from app.dependencies import get_workflow_service, get_html_renderer
+
 from app.core.html_renderer import HtmlRendererInterface
-from app.db_models.enums import WorkflowStatus
 from app.core.security import AuthenticatedUser, get_current_active_user
+from app.db_models.enums import WorkflowStatus
+from app.dependencies import get_workflow_service, get_html_renderer
+from app.services import WorkflowService
 
 router = APIRouter(tags=["user_workflows"])
+
 
 @router.get("/my-workflows", response_class=HTMLResponse)
 async def list_user_workflows(
@@ -32,9 +34,9 @@ async def list_user_workflows(
         except ValueError:
             # Invalid date format, default to today's date
             created_at_for_service = date.today()
-    else: # No date query param or it's empty, default to today's date
+    else:  # No date query param or it's empty, default to today's date
         created_at_for_service = date.today()
-            
+
     selected_created_at_str = created_at_for_service.isoformat()
 
     # New status handling logic
@@ -60,8 +62,8 @@ async def list_user_workflows(
 
     instances = await service.list_instances_for_user(
         user_id=current_user.user_id,
-        created_at_date=created_at_for_service, # Pass the determined date object
-        status=status_for_service # Pass the refined status for service (can be None)
+        created_at_date=created_at_for_service,  # Pass the determined date object
+        status=status_for_service  # Pass the refined status for service (can be None)
     )
 
     # For the template, if 'created_at' (the string query param) was provided, use it.
@@ -73,7 +75,7 @@ async def list_user_workflows(
         {
             "instances": instances,
             "selected_created_at": selected_created_at_str,
-            "selected_status": selected_status_for_template, # Use the newly determined value
-            "workflow_statuses": [s.value for s in WorkflowStatus] # For dropdown
+            "selected_status": selected_status_for_template,  # Use the newly determined value
+            "workflow_statuses": [s.value for s in WorkflowStatus]  # For dropdown
         }
     )

--- a/app/routers/user_workflows.py
+++ b/app/routers/user_workflows.py
@@ -1,3 +1,4 @@
+from typing import Optional # Added import
 from fastapi import APIRouter, Request, Depends, Query
 from fastapi.responses import HTMLResponse, RedirectResponse
 from datetime import date

--- a/app/routers/workflow_definitions.py
+++ b/app/routers/workflow_definitions.py
@@ -1,14 +1,17 @@
 from typing import Optional
+
 from fastapi import APIRouter, Request, Form, Depends, Query
-from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi import status
-from app.services import WorkflowService
+from fastapi.responses import HTMLResponse, RedirectResponse
+
 from app.core.html_renderer import HtmlRendererInterface
 from app.core.security import AuthenticatedUser, get_current_active_user
 from app.dependencies import get_workflow_service, get_html_renderer
+from app.services import WorkflowService
 from app.utils import create_message_page
 
 router = APIRouter(prefix="/workflow-definitions", tags=["workflow_definitions"])
+
 
 @router.get("", response_class=HTMLResponse)
 async def list_workflow_definitions_page(
@@ -24,6 +27,7 @@ async def list_workflow_definitions_page(
         {"definitions": definitions, "current_filter_name": name}
     )
 
+
 @router.get("/create", response_class=HTMLResponse)
 async def create_workflow_definition_page(
         request: Request,
@@ -35,15 +39,16 @@ async def create_workflow_definition_page(
         return current_user
     return await renderer.render("create_workflow_definition.html", request, {})
 
+
 @router.post("/create", response_class=RedirectResponse)
 async def create_workflow_definition_handler(
-    request: Request,
-    name: str = Form(...),
-    description: str = Form(default=""),
-    task_names_str: str = Form(...),
-    service: WorkflowService = Depends(get_workflow_service),
-    current_user: AuthenticatedUser = Depends(get_current_active_user),
-    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+        request: Request,
+        name: str = Form(...),
+        description: str = Form(default=""),
+        task_names_str: str = Form(...),
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
     """Handles the submission of a new workflow definition."""
     if isinstance(current_user, RedirectResponse):
@@ -55,21 +60,23 @@ async def create_workflow_definition_handler(
     except ValueError as e:
         return await create_message_page(
             request,
-            "Creation Failed", 
-            "Error", 
+            "Creation Failed",
+            "Error",
             str(e),
-            [("← Back to Create Template", "/workflow-definitions/create"), ("← Back to Definitions", "/workflow-definitions")],
+            [("← Back to Create Template", "/workflow-definitions/create"),
+             ("← Back to Definitions", "/workflow-definitions")],
             status_code=400,
             renderer=renderer
         )
 
+
 @router.get("/edit/{definition_id}", response_class=HTMLResponse)
 async def edit_workflow_definition_page(
-    request: Request, 
-    definition_id: str, 
-    service: WorkflowService = Depends(get_workflow_service),
-    current_user: AuthenticatedUser = Depends(get_current_active_user),
-    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+        request: Request,
+        definition_id: str,
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
     """Serves a page for editing an existing workflow definition."""
     if isinstance(current_user, RedirectResponse):
@@ -78,38 +85,40 @@ async def edit_workflow_definition_page(
     if not definition:
         return await create_message_page(
             request,
-            "Not Found", 
-            "Error 404", 
+            "Not Found",
+            "Error 404",
             f"Workflow Definition with ID '{definition_id}' not found.",
             [("← Back to Definitions", "/workflow-definitions")],
             status_code=404,
             renderer=renderer
         )
-    
+
     return await renderer.render("edit_workflow_definition.html", request, {"definition": definition})
+
 
 @router.post("/edit/{definition_id}", response_class=RedirectResponse)
 async def edit_workflow_definition_handler(
-    request: Request,
-    definition_id: str,
-    name: str = Form(...),
-    description: str = Form(default=""),
-    task_names_str: str = Form(...),
-    service: WorkflowService = Depends(get_workflow_service),
-    current_user: AuthenticatedUser = Depends(get_current_active_user),
-    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+        request: Request,
+        definition_id: str,
+        name: str = Form(...),
+        description: str = Form(default=""),
+        task_names_str: str = Form(...),
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
     """Handles the submission of updates to an existing workflow definition."""
     if isinstance(current_user, RedirectResponse):
         return current_user
     try:
         task_names = [task.strip() for task in task_names_str.split('\n') if task.strip()]
-        updated_definition = await service.update_definition(definition_id=definition_id, name=name, description=description, task_names=task_names)
+        updated_definition = await service.update_definition(definition_id=definition_id, name=name,
+                                                             description=description, task_names=task_names)
         if not updated_definition:
             return await create_message_page(
                 request,
-                "Update Failed", 
-                "Error 404", 
+                "Update Failed",
+                "Error 404",
                 f"Workflow Definition with ID '{definition_id}' not found.",
                 [("← Back to Definitions", "/workflow-definitions")],
                 status_code=404,
@@ -119,21 +128,23 @@ async def edit_workflow_definition_handler(
     except ValueError as e:
         return await create_message_page(
             request,
-            "Update Failed", 
-            "Error", 
+            "Update Failed",
+            "Error",
             str(e),
-            [("← Back to Edit Template", f"/workflow-definitions/edit/{definition_id}"), ("← Back to Definitions", "/workflow-definitions")],
+            [("← Back to Edit Template", f"/workflow-definitions/edit/{definition_id}"),
+             ("← Back to Definitions", "/workflow-definitions")],
             status_code=400,
             renderer=renderer
         )
 
+
 @router.get("/confirm-delete-workflow-definition/{definition_id}", response_class=HTMLResponse)
 async def confirm_delete_workflow_definition_page(
-    request: Request, 
-    definition_id: str, 
-    service: WorkflowService = Depends(get_workflow_service),
-    current_user: AuthenticatedUser = Depends(get_current_active_user),
-    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+        request: Request,
+        definition_id: str,
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
     """Serves a confirmation page for deleting a workflow definition."""
     if isinstance(current_user, RedirectResponse):
@@ -142,23 +153,24 @@ async def confirm_delete_workflow_definition_page(
     if not definition:
         return await create_message_page(
             request,
-            "Not Found", 
-            "Error 404", 
+            "Not Found",
+            "Error 404",
             f"Workflow Definition with ID '{definition_id}' not found.",
             [("← Back to Definitions", "/workflow-definitions")],
             status_code=404,
             renderer=renderer
         )
-    
+
     return await renderer.render("confirm_delete_workflow_definition.html", request, {"definition": definition})
+
 
 @router.post("/delete-workflow-definition/{definition_id}", response_class=RedirectResponse)
 async def delete_workflow_definition_handler(
-    request: Request,
-    definition_id: str,
-    service: WorkflowService = Depends(get_workflow_service),
-    current_user: AuthenticatedUser = Depends(get_current_active_user),
-    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+        request: Request,
+        definition_id: str,
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
     """Handles the deletion of a workflow definition."""
     if isinstance(current_user, RedirectResponse):
@@ -173,8 +185,8 @@ async def delete_workflow_definition_handler(
             status_code = 404
         return await create_message_page(
             request,
-            "Deletion Failed", 
-            "Error" + ( " 404" if status_code == 404 else "" ),
+            "Deletion Failed",
+            "Error" + (" 404" if status_code == 404 else ""),
             error_message,
             [("← Back to Definitions", "/workflow-definitions")],
             status_code=status_code,

--- a/app/routers/workflow_instances.py
+++ b/app/routers/workflow_instances.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Request, Form, Depends
-from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi import status
-from app.services import WorkflowService
-from app.models import WorkflowStatus # Added import
+from fastapi.responses import HTMLResponse, RedirectResponse
+
 from app.core.html_renderer import HtmlRendererInterface
 from app.core.security import AuthenticatedUser, get_current_active_user
 from app.dependencies import get_workflow_service, get_html_renderer
+from app.models import WorkflowStatus  # Added import
+from app.services import WorkflowService
 from app.utils import create_message_page
 
 router = APIRouter(prefix="/workflow-instances", tags=["workflow_instances"])
+
 
 @router.post("", response_class=RedirectResponse)
 async def create_workflow_instance_handler(
@@ -27,6 +29,7 @@ async def create_workflow_instance_handler(
             [("← Definitions", "/workflow-definitions")], status_code=500, renderer=renderer
         )
     return RedirectResponse(url=f"/workflow-instances/{instance.id}", status_code=status.HTTP_303_SEE_OTHER)
+
 
 @router.get("/{instance_id}", response_class=HTMLResponse)
 async def read_workflow_instance_page(
@@ -54,6 +57,7 @@ async def read_workflow_instance_page(
         {"instance": instance, "tasks": tasks}
     )
 
+
 @router.post("/{instance_id}/archive", response_class=HTMLResponse)
 async def archive_workflow_instance_handler(
         request: Request,
@@ -62,7 +66,7 @@ async def archive_workflow_instance_handler(
         current_user: AuthenticatedUser = Depends(get_current_active_user),
         renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
-    if isinstance(current_user, RedirectResponse): # Handles unauthenticated users
+    if isinstance(current_user, RedirectResponse):  # Handles unauthenticated users
         return current_user
 
     # Attempt to archive the instance
@@ -84,36 +88,36 @@ async def archive_workflow_instance_handler(
             # This implies instance_id is invalid or user does not own it.
             # The service.archive_workflow_instance would have returned None.
             return await create_message_page(
-                request, "Not Found", "Error 404", 
+                request, "Not Found", "Error 404",
                 f"Workflow Instance with ID '{instance_id}' not found or you do not have permission to view it.",
-                [("← Back to Definitions", "/workflow-definitions")], 
+                [("← Back to Definitions", "/workflow-definitions")],
                 status_code=404, renderer=renderer
             )
-        
+
         instance_obj = instance_details["instance"]
 
         # If instance exists and belongs to user, but archiving failed, it's likely because it's completed.
         if instance_obj.status == WorkflowStatus.completed:
             return await create_message_page(
-                request, "Archiving Failed", "Error 400 - Bad Request", 
+                request, "Archiving Failed", "Error 400 - Bad Request",
                 "Cannot archive a workflow instance that is already completed.",
-                [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+                [(f"← Back to Instance", f"/workflow-instances/{instance_id}")],
                 status_code=status.HTTP_400_BAD_REQUEST, renderer=renderer
             )
-        
+
         # If it's already archived (should have been returned by archive_workflow_instance directly, but as a fallback)
         if instance_obj.status == WorkflowStatus.archived:
-             return RedirectResponse(url=f"/workflow-instances/{instance_id}", status_code=status.HTTP_303_SEE_OTHER)
-
+            return RedirectResponse(url=f"/workflow-instances/{instance_id}", status_code=status.HTTP_303_SEE_OTHER)
 
         # Default error if none of the above specific conditions were met
         # This could be due to some other unexpected state or error in the service layer.
         return await create_message_page(
-            request, "Archiving Failed", "Error 500 - Server Error", 
+            request, "Archiving Failed", "Error 500 - Server Error",
             "Could not archive the workflow instance due to an unexpected error.",
-            [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+            [(f"← Back to Instance", f"/workflow-instances/{instance_id}")],
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, renderer=renderer
         )
+
 
 @router.post("/{instance_id}/unarchive", response_class=HTMLResponse)
 async def unarchive_workflow_instance_handler(
@@ -123,7 +127,7 @@ async def unarchive_workflow_instance_handler(
         current_user: AuthenticatedUser = Depends(get_current_active_user),
         renderer: HtmlRendererInterface = Depends(get_html_renderer)
 ):
-    if isinstance(current_user, RedirectResponse): # Handles unauthenticated users
+    if isinstance(current_user, RedirectResponse):  # Handles unauthenticated users
         return current_user
 
     unarchived_instance_result = await service.unarchive_workflow_instance(instance_id, current_user.user_id)
@@ -139,27 +143,27 @@ async def unarchive_workflow_instance_handler(
         if not instance_details or not instance_details["instance"]:
             # Instance not found or user does not have permission.
             return await create_message_page(
-                request, "Not Found", "Error 404", 
+                request, "Not Found", "Error 404",
                 f"Workflow Instance with ID '{instance_id}' not found or you do not have permission to view it.",
-                [("← Back to Definitions", "/workflow-definitions")], 
+                [("← Back to Definitions", "/workflow-definitions")],
                 status_code=status.HTTP_404_NOT_FOUND, renderer=renderer
             )
-        
+
         instance_obj = instance_details["instance"]
 
         # If instance exists and belongs to user, but unarchiving failed, it's likely because it's not archived.
-        if instance_obj.status != WorkflowStatus.ARCHIVED:
+        if instance_obj.status != WorkflowStatus.archived:
             return await create_message_page(
-                request, "Unarchiving Failed", "Error 400 - Bad Request", 
+                request, "Unarchiving Failed", "Error 400 - Bad Request",
                 "Cannot unarchive a workflow instance that is not currently archived.",
-                [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+                [(f"← Back to Instance", f"/workflow-instances/{instance_id}")],
                 status_code=status.HTTP_400_BAD_REQUEST, renderer=renderer
             )
-        
+
         # Default error if none of the above specific conditions were met (e.g., unexpected service layer issue)
         return await create_message_page(
-            request, "Unarchiving Failed", "Error 500 - Server Error", 
+            request, "Unarchiving Failed", "Error 500 - Server Error",
             "Could not unarchive the workflow instance due to an unexpected error.",
-            [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+            [(f"← Back to Instance", f"/workflow-instances/{instance_id}")],
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, renderer=renderer
         )

--- a/app/routers/workflow_instances.py
+++ b/app/routers/workflow_instances.py
@@ -114,3 +114,52 @@ async def archive_workflow_instance_handler(
             [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, renderer=renderer
         )
+
+@router.post("/{instance_id}/unarchive", response_class=HTMLResponse)
+async def unarchive_workflow_instance_handler(
+        request: Request,
+        instance_id: str,
+        service: WorkflowService = Depends(get_workflow_service),
+        current_user: AuthenticatedUser = Depends(get_current_active_user),
+        renderer: HtmlRendererInterface = Depends(get_html_renderer)
+):
+    if isinstance(current_user, RedirectResponse): # Handles unauthenticated users
+        return current_user
+
+    unarchived_instance_result = await service.unarchive_workflow_instance(instance_id, current_user.user_id)
+
+    if unarchived_instance_result:
+        # If successful and instance is now active, redirect
+        return RedirectResponse(url=f"/workflow-instances/{instance_id}", status_code=status.HTTP_303_SEE_OTHER)
+    else:
+        # Unarchiving failed, determine why for a more specific error message.
+        # Re-fetch the instance details to provide accurate error feedback.
+        instance_details = await service.get_workflow_instance_with_tasks(instance_id, current_user.user_id)
+
+        if not instance_details or not instance_details["instance"]:
+            # Instance not found or user does not have permission.
+            return await create_message_page(
+                request, "Not Found", "Error 404", 
+                f"Workflow Instance with ID '{instance_id}' not found or you do not have permission to view it.",
+                [("← Back to Definitions", "/workflow-definitions")], 
+                status_code=status.HTTP_404_NOT_FOUND, renderer=renderer
+            )
+        
+        instance_obj = instance_details["instance"]
+
+        # If instance exists and belongs to user, but unarchiving failed, it's likely because it's not archived.
+        if instance_obj.status != WorkflowStatus.ARCHIVED:
+            return await create_message_page(
+                request, "Unarchiving Failed", "Error 400 - Bad Request", 
+                "Cannot unarchive a workflow instance that is not currently archived.",
+                [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+                status_code=status.HTTP_400_BAD_REQUEST, renderer=renderer
+            )
+        
+        # Default error if none of the above specific conditions were met (e.g., unexpected service layer issue)
+        return await create_message_page(
+            request, "Unarchiving Failed", "Error 500 - Server Error", 
+            "Could not unarchive the workflow instance due to an unexpected error.",
+            [(f"← Back to Instance", f"/workflow-instances/{instance_id}")], 
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, renderer=renderer
+        )

--- a/app/services.py
+++ b/app/services.py
@@ -1,13 +1,14 @@
 # services.py
-from typing import List, Optional, Dict, Any
 from datetime import date as DateObject
+from typing import List, Optional, Dict, Any
 
 from app.models import WorkflowDefinition, WorkflowInstance, TaskInstance, TaskStatus, WorkflowStatus
 from app.repository import WorkflowDefinitionRepository, WorkflowInstanceRepository, TaskInstanceRepository
 
 
 class WorkflowService:
-    def __init__(self, definition_repo: WorkflowDefinitionRepository, instance_repo: WorkflowInstanceRepository, task_repo: TaskInstanceRepository):
+    def __init__(self, definition_repo: WorkflowDefinitionRepository, instance_repo: WorkflowInstanceRepository,
+                 task_repo: TaskInstanceRepository):
         self.definition_repo = definition_repo
         self.instance_repo = instance_repo
         self.task_repo = task_repo
@@ -66,15 +67,18 @@ class WorkflowService:
                     await self.instance_repo.update_workflow_instance(workflow_instance.id, workflow_instance)
         return updated_task
 
-    async def list_instances_for_user(self, user_id: str, created_at_date: Optional[DateObject] = None, status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
-        return await self.instance_repo.list_workflow_instances_by_user(user_id, created_at_date=created_at_date, status=status)
+    async def list_instances_for_user(self, user_id: str, created_at_date: Optional[DateObject] = None,
+                                      status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
+        return await self.instance_repo.list_workflow_instances_by_user(user_id, created_at_date=created_at_date,
+                                                                        status=status)
 
-    async def create_new_definition(self, name: str, description: Optional[str], task_names: List[str]) -> WorkflowDefinition:
+    async def create_new_definition(self, name: str, description: Optional[str],
+                                    task_names: List[str]) -> WorkflowDefinition:
         if not name.strip():
             raise ValueError("Definition name cannot be empty.")
         if not task_names:
             raise ValueError("A definition must have at least one task name.")
-        
+
         definition = WorkflowDefinition(
             name=name,
             description=description,
@@ -82,12 +86,13 @@ class WorkflowService:
         )
         return await self.definition_repo.create_workflow_definition(definition)
 
-    async def update_definition(self, definition_id: str, name: str, description: Optional[str], task_names: List[str]) -> Optional[WorkflowDefinition]:
+    async def update_definition(self, definition_id: str, name: str, description: Optional[str],
+                                task_names: List[str]) -> Optional[WorkflowDefinition]:
         if not name.strip():
             raise ValueError("Definition name cannot be empty.")
         if not task_names:
             raise ValueError("A definition must have at least one task name.")
-        
+
         return await self.definition_repo.update_workflow_definition(definition_id, name, description, task_names)
 
     async def delete_definition(self, definition_id: str) -> None:
@@ -131,7 +136,7 @@ class WorkflowService:
             # Cannot archive a completed instance, return None or raise error
             # For now, returning None as per subtask description ("return None")
             return None
-        
+
         if instance.status == WorkflowStatus.archived:
             # Already archived, return the instance as is
             return instance
@@ -144,15 +149,15 @@ class WorkflowService:
         instance = await self.instance_repo.get_workflow_instance_by_id(instance_id)
 
         if not instance:
-            return None # Instance not found
+            return None  # Instance not found
 
         if instance.user_id != user_id:
-            return None # User does not own this instance
+            return None  # User does not own this instance
 
-        if instance.status != WorkflowStatus.ARCHIVED:
+        if instance.status != WorkflowStatus.archived:
             # Can only unarchive instances that are currently archived
-            return None 
-        
-        instance.status = WorkflowStatus.active # Set status to active
+            return None
+
+        instance.status = WorkflowStatus.active  # Set status to active
         updated_instance = await self.instance_repo.update_workflow_instance(instance.id, instance)
         return updated_instance

--- a/app/services.py
+++ b/app/services.py
@@ -139,3 +139,20 @@ class WorkflowService:
         instance.status = WorkflowStatus.ARCHIVED
         updated_instance = await self.instance_repo.update_workflow_instance(instance.id, instance)
         return updated_instance
+
+    async def unarchive_workflow_instance(self, instance_id: str, user_id: str) -> Optional[WorkflowInstance]:
+        instance = await self.instance_repo.get_workflow_instance_by_id(instance_id)
+
+        if not instance:
+            return None # Instance not found
+
+        if instance.user_id != user_id:
+            return None # User does not own this instance
+
+        if instance.status != WorkflowStatus.ARCHIVED:
+            # Can only unarchive instances that are currently archived
+            return None 
+        
+        instance.status = WorkflowStatus.active # Set status to active
+        updated_instance = await self.instance_repo.update_workflow_instance(instance.id, instance)
+        return updated_instance

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,9 +7,9 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="container">
-        {% block content %}
-        {% endblock %}
-    </div>
+<div class="container">
+    {% block content %}
+    {% endblock %}
+</div>
 </body>
 </html>

--- a/app/templates/confirm_delete_workflow_definition.html
+++ b/app/templates/confirm_delete_workflow_definition.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Confirm Delete: {{ definition.name }}</h1>
-    <p>Are you sure you want to delete the workflow definition '{{ definition.name }}'? This action cannot be undone.</p>
-    <form action="/workflow-definitions/delete-workflow-definition/{{ definition.id }}" method="post">
-        <button type="submit" class="action-button cancel">Yes, Delete Permanently</button>
-    </form>
-    <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">No, Cancel</a>
+<h1>Confirm Delete: {{ definition.name }}</h1>
+<p>Are you sure you want to delete the workflow definition '{{ definition.name }}'? This action cannot be undone.</p>
+<form action="/workflow-definitions/delete-workflow-definition/{{ definition.id }}" method="post">
+    <button type="submit" class="action-button cancel">Yes, Delete Permanently</button>
+</form>
+<a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">No, Cancel</a>
 {% endblock %}

--- a/app/templates/create_workflow_definition.html
+++ b/app/templates/create_workflow_definition.html
@@ -1,22 +1,24 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Create New Checklist Template</h1>
-    <form action="/workflow-definitions/create" method="post">
-        <div>
-            <label for="name">Definition Name:</label>
-            <input type="text" name="name" id="name" required>
-        </div>
-        <div>
-            <label for="description">Description:</label>
-            <textarea name="description" id="description" rows="3"></textarea>
-        </div>
-        <div>
-            <label for="task_names_str">Task Names (one per line):</label>
-            <textarea name="task_names_str" id="task_names_str" rows="5" placeholder="Enter one task name per line" required></textarea>
-        </div>
-        <button type="submit" class="action-button submit">Create Template</button>
-    </form>
-    <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Available Definitions</a>
-    <a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
+<h1>Create New Checklist Template</h1>
+<form action="/workflow-definitions/create" method="post">
+    <div>
+        <label for="name">Definition Name:</label>
+        <input type="text" name="name" id="name" required>
+    </div>
+    <div>
+        <label for="description">Description:</label>
+        <textarea name="description" id="description" rows="3"></textarea>
+    </div>
+    <div>
+        <label for="task_names_str">Task Names (one per line):</label>
+        <textarea name="task_names_str" id="task_names_str" rows="5" placeholder="Enter one task name per line"
+                  required></textarea>
+    </div>
+    <button type="submit" class="action-button submit">Create Template</button>
+</form>
+<a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Available
+    Definitions</a>
+<a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
 {% endblock %}

--- a/app/templates/edit_workflow_definition.html
+++ b/app/templates/edit_workflow_definition.html
@@ -1,22 +1,24 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Edit Checklist Template: {{ definition.name }}</h1>
-    <form action="/workflow-definitions/edit/{{ definition.id }}" method="post">
-        <div>
-            <label for="name">Definition Name:</label>
-            <input type="text" name="name" id="name" value="{{ definition.name }}" required>
-        </div>
-        <div>
-            <label for="description">Description:</label>
-            <textarea name="description" id="description" rows="3">{{ definition.description or "" }}</textarea>
-        </div>
-        <div>
-            <label for="task_names_str">Task Names (one per line):</label>
-            <textarea name="task_names_str" id="task_names_str" rows="5" placeholder="Enter one task name per line" required>{{ "\n".join(definition.task_names) }}</textarea>
-        </div>
-        <button type="submit" class="action-button submit">Save Changes</button>
-    </form>
-    <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Available Definitions</a>
-    <a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
+<h1>Edit Checklist Template: {{ definition.name }}</h1>
+<form action="/workflow-definitions/edit/{{ definition.id }}" method="post">
+    <div>
+        <label for="name">Definition Name:</label>
+        <input type="text" name="name" id="name" value="{{ definition.name }}" required>
+    </div>
+    <div>
+        <label for="description">Description:</label>
+        <textarea name="description" id="description" rows="3">{{ definition.description or "" }}</textarea>
+    </div>
+    <div>
+        <label for="task_names_str">Task Names (one per line):</label>
+        <textarea name="task_names_str" id="task_names_str" rows="5" placeholder="Enter one task name per line"
+                  required>{{ "\n".join(definition.task_names) }}</textarea>
+    </div>
+    <button type="submit" class="action-button submit">Save Changes</button>
+</form>
+<a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Available
+    Definitions</a>
+<a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,17 +1,18 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Simple Checklist MVP</h1>
-    <p>Manage your simple checklist workflows.</p>
-    <h2>Workflows:</h2>
-    <ul>
-        <li><a href="/workflow-definitions" class="action-button">Available Workflow Definitions</a></li>
-        {% if current_user %}
-            <li><a href="/my-workflows" class="action-button">My Workflows</a></li>
-            <li><a href="#" class="action-button disabled" style="pointer-events: none;">Logged in as: {{ current_user.username }}</a></li>
-            <li><a href="/logout" class="action-button">Logout</a></li>
-        {% else %}
-            <li><a href="/login" class="action-button">Login to View/Create Workflows</a></li>
-        {% endif %}
-    </ul>
+<h1>Simple Checklist MVP</h1>
+<p>Manage your simple checklist workflows.</p>
+<h2>Workflows:</h2>
+<ul>
+    <li><a href="/workflow-definitions" class="action-button">Available Workflow Definitions</a></li>
+    {% if current_user %}
+    <li><a href="/my-workflows" class="action-button">My Workflows</a></li>
+    <li><a href="#" class="action-button disabled" style="pointer-events: none;">Logged in as: {{ current_user.username
+        }}</a></li>
+    <li><a href="/logout" class="action-button">Logout</a></li>
+    {% else %}
+    <li><a href="/login" class="action-button">Login to View/Create Workflows</a></li>
+    {% endif %}
+</ul>
 {% endblock %}

--- a/app/templates/message.html
+++ b/app/templates/message.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1 style="{{ heading_style }}">{{ heading }}</h1>
-    <p>{{ message }}</p>
-    {% for link_text, link_href in links %}
-        <a href="{{ link_href }}" class="back-link" style="margin-right:15px; display:inline-block; margin-top:10px;">{{ link_text }}</a>
-    {% endfor %}
+<h1 style="{{ heading_style }}">{{ heading }}</h1>
+<p>{{ message }}</p>
+{% for link_text, link_href in links %}
+<a href="{{ link_href }}" class="back-link" style="margin-right:15px; display:inline-block; margin-top:10px;">{{
+    link_text }}</a>
+{% endfor %}
 {% endblock %}

--- a/app/templates/my_workflows.html
+++ b/app/templates/my_workflows.html
@@ -1,46 +1,46 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>My Workflows</h1>
+<h1>My Workflows</h1>
 
-    <form method="GET" action="{{ request.url.path }}" class="filter-form">
-        <div class="filter-group">
-            <label for="created_at">Created Date:</label>
-            <input type="date" id="created_at" name="created_at" value="{{ selected_created_at }}">
-        </div>
-        <div class="filter-group">
-            <label for="status">Status:</label>
-            <select id="status" name="status">
-                <option value="">All Statuses</option>
-                {% for status_value in workflow_statuses %}
-                    <option value="{{ status_value }}" {% if status_value == selected_status %}selected{% endif %}>
-                        {{ status_value.replace('_', ' ').title() }}
-                    </option>
-                {% endfor %}
-            </select>
-        </div>
-        <button type="submit" class="action-button">Apply Filters</button>
-    </form>
-
-    {% if not instances %}
-        <p>You have no workflows yet.</p>
-    {% else %}
-        <ul>
-            {% for instance in instances %}
-                <li class="wip-list-item">
-                    <h2>{{ instance.name }}</h2>
-                    <p><strong>Status:</strong> {{ instance.status.value.replace('_', ' ').title() }}</p>
-                    <p><strong>Created:</strong> {{ instance.created_at.isoformat() }}</p>
-                    <a href="/workflow-instances/{{ instance.id }}" class="action-button">View Details</a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
-
-    <div class="page-actions">
-        <a href="/" class="back-link">← Back to Home</a>
-        <a href="/workflow-definitions" class="back-link">← Available Definitions</a>
-        <a href="/workflow-definitions/create" class="action-button">Create New Checklist Template</a>
-        <a href="/logout" class="back-link">Logout</a>
+<form method="GET" action="{{ request.url.path }}" class="filter-form">
+    <div class="filter-group">
+        <label for="created_at">Created Date:</label>
+        <input type="date" id="created_at" name="created_at" value="{{ selected_created_at }}">
     </div>
+    <div class="filter-group">
+        <label for="status">Status:</label>
+        <select id="status" name="status">
+            <option value="">All Statuses</option>
+            {% for status_value in workflow_statuses %}
+            <option value="{{ status_value }}" {% if status_value== selected_status %}selected{% endif %}>
+                {{ status_value.replace('_', ' ').title() }}
+            </option>
+            {% endfor %}
+        </select>
+    </div>
+    <button type="submit" class="action-button">Apply Filters</button>
+</form>
+
+{% if not instances %}
+<p>You have no workflows yet.</p>
+{% else %}
+<ul>
+    {% for instance in instances %}
+    <li class="wip-list-item">
+        <h2>{{ instance.name }}</h2>
+        <p><strong>Status:</strong> {{ instance.status.value.replace('_', ' ').title() }}</p>
+        <p><strong>Created:</strong> {{ instance.created_at.isoformat() }}</p>
+        <a href="/workflow-instances/{{ instance.id }}" class="action-button">View Details</a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+<div class="page-actions">
+    <a href="/" class="back-link">← Back to Home</a>
+    <a href="/workflow-definitions" class="back-link">← Available Definitions</a>
+    <a href="/workflow-definitions/create" class="action-button">Create New Checklist Template</a>
+    <a href="/logout" class="back-link">Logout</a>
+</div>
 {% endblock %}

--- a/app/templates/style.css
+++ b/app/templates/style.css
@@ -1,12 +1,57 @@
-body { font-family: 'Inter', sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
-.container { max-width: 800px; margin: auto; padding: 20px; background-color: #fff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-h1 { color: #1a202c; margin-bottom: 20px; }
-h2 { color: #2d3748; margin-top: 30px; margin-bottom: 15px; border-bottom: 1px solid #eee; padding-bottom: 10px; }
-p { line-height: 1.6; margin-bottom: 10px; }
-ul { list-style-type: none; padding: 0; }
-li { margin-bottom: 8px; }
-a { color: #3182ce; text-decoration: none; transition: color 0.2s ease-in-out; }
-a:hover { color: #2b6cb0; text-decoration: underline; }
+body {
+    font-family: 'Inter', sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    color: #1a202c;
+    margin-bottom: 20px;
+}
+
+h2 {
+    color: #2d3748;
+    margin-top: 30px;
+    margin-bottom: 15px;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+}
+
+p {
+    line-height: 1.6;
+    margin-bottom: 10px;
+}
+
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+li {
+    margin-bottom: 8px;
+}
+
+a {
+    color: #3182ce;
+    text-decoration: none;
+    transition: color 0.2s ease-in-out;
+}
+
+a:hover {
+    color: #2b6cb0;
+    text-decoration: underline;
+}
+
 button, input[type="submit"] {
     background-color: #4299e1;
     color: white;
@@ -16,12 +61,30 @@ button, input[type="submit"] {
     cursor: pointer;
     font-size: 16px;
     transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
-button:hover, input[type="submit"]:hover { background-color: #3182ce; transform: translateY(-1px); }
-button:active, input[type="submit"]:active { transform: translateY(0); }
-.back-link { display: inline-block; margin-top: 20px; color: #4a5568; text-decoration: none; }
-.back-link:hover { color: #2d3748; text-decoration: underline; }
+
+button:hover, input[type="submit"]:hover {
+    background-color: #3182ce;
+    transform: translateY(-1px);
+}
+
+button:active, input[type="submit"]:active {
+    transform: translateY(0);
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 20px;
+    color: #4a5568;
+    text-decoration: none;
+}
+
+.back-link:hover {
+    color: #2d3748;
+    text-decoration: underline;
+}
+
 .action-button {
     display: inline-block;
     padding: 10px 15px;
@@ -31,18 +94,66 @@ button:active, input[type="submit"]:active { transform: translateY(0); }
     margin-bottom: 10px;
     font-weight: bold;
     transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
-.action-button.submit { background-color: #48bb78; color: white; }
-.action-button.submit:hover { background-color: #38a169; transform: translateY(-1px); }
-.action-button.cancel { background-color: #ef4444; color: white; }
-.action-button.cancel:hover { background-color: #dc2626; transform: translateY(-1px); }
-.action-button.share { background-color: #f6ad55; color: white; }
-.action-button.share:hover { background-color: #ed8936; transform: translateY(-1px); }
-.create-wip-link { background-color: #3182ce; color: white; padding: 10px 15px; border-radius: 6px; text-decoration: none; display: inline-block; margin-top: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-.create-wip-link:hover { background-color: #2b6cb0; transform: translateY(-1px); }
-form div { margin-bottom: 15px; }
-label { display: block; margin-bottom: 5px; font-weight: bold; color: #4a5568; }
+
+.action-button.submit {
+    background-color: #48bb78;
+    color: white;
+}
+
+.action-button.submit:hover {
+    background-color: #38a169;
+    transform: translateY(-1px);
+}
+
+.action-button.cancel {
+    background-color: #ef4444;
+    color: white;
+}
+
+.action-button.cancel:hover {
+    background-color: #dc2626;
+    transform: translateY(-1px);
+}
+
+.action-button.share {
+    background-color: #f6ad55;
+    color: white;
+}
+
+.action-button.share:hover {
+    background-color: #ed8936;
+    transform: translateY(-1px);
+}
+
+.create-wip-link {
+    background-color: #3182ce;
+    color: white;
+    padding: 10px 15px;
+    border-radius: 6px;
+    text-decoration: none;
+    display: inline-block;
+    margin-top: 20px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.create-wip-link:hover {
+    background-color: #2b6cb0;
+    transform: translateY(-1px);
+}
+
+form div {
+    margin-bottom: 15px;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #4a5568;
+}
+
 input[type="text"], input[type="date"], input[type="email"], select, textarea {
     width: 100%;
     padding: 10px;
@@ -52,29 +163,92 @@ input[type="text"], input[type="date"], input[type="email"], select, textarea {
     font-size: 16px;
     transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
+
 input[type="text"]:focus, input[type="date"]:focus, input[type="email"]:focus, select:focus, textarea:focus {
     border-color: #63b3ed;
     box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
     outline: none;
 }
+
 .wip-list-item {
     background-color: #f7fafc;
     border: 1px solid #e2e8f0;
     border-radius: 8px;
     padding: 15px;
     margin-bottom: 15px;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
-.wip-list-item p { margin: 0 0 5px 0; }
-.wip-list-item strong { color: #2d3748; }
-.wip-list-item a { margin-top: 10px; display: inline-block; }
-.filter-form { margin-bottom: 20px; padding: 15px; background-color: #e9ecef; border-radius: 6px; }
-.filter-form h2 { margin-top:0; margin-bottom:15px; font-size: 1.2em; color: #2d3748; }
-.filter-form div { display: inline-block; margin-right: 15px; margin-bottom: 10px; vertical-align: top;}
-.filter-form label { font-size: 0.9em; margin-bottom: 3px; }
-.filter-form input[type="text"], .filter-form select { width: auto; min-width:150px; padding: 8px; font-size: 0.95em; }
-.filter-form button { padding: 8px 15px; font-size: 0.95em; background-color: #5a67d8; }
-.filter-form button:hover { background-color: #4c51bf; }
-.share-form label { font-size: 0.9em; }
-.share-form input[type="email"] { width: 70%; display: inline-block; margin-right:10px; padding: 8px; font-size: 0.95em;}
-.share-form button { font-size: 14px; padding: 8px 12px; vertical-align: baseline;}
+
+.wip-list-item p {
+    margin: 0 0 5px 0;
+}
+
+.wip-list-item strong {
+    color: #2d3748;
+}
+
+.wip-list-item a {
+    margin-top: 10px;
+    display: inline-block;
+}
+
+.filter-form {
+    margin-bottom: 20px;
+    padding: 15px;
+    background-color: #e9ecef;
+    border-radius: 6px;
+}
+
+.filter-form h2 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    font-size: 1.2em;
+    color: #2d3748;
+}
+
+.filter-form div {
+    display: inline-block;
+    margin-right: 15px;
+    margin-bottom: 10px;
+    vertical-align: top;
+}
+
+.filter-form label {
+    font-size: 0.9em;
+    margin-bottom: 3px;
+}
+
+.filter-form input[type="text"], .filter-form select {
+    width: auto;
+    min-width: 150px;
+    padding: 8px;
+    font-size: 0.95em;
+}
+
+.filter-form button {
+    padding: 8px 15px;
+    font-size: 0.95em;
+    background-color: #5a67d8;
+}
+
+.filter-form button:hover {
+    background-color: #4c51bf;
+}
+
+.share-form label {
+    font-size: 0.9em;
+}
+
+.share-form input[type="email"] {
+    width: 70%;
+    display: inline-block;
+    margin-right: 10px;
+    padding: 8px;
+    font-size: 0.95em;
+}
+
+.share-form button {
+    font-size: 14px;
+    padding: 8px 12px;
+    vertical-align: baseline;
+}

--- a/app/templates/workflow_definitions.html
+++ b/app/templates/workflow_definitions.html
@@ -1,28 +1,30 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Available Workflow Definitions</h1>
-    {% if not definitions %}
-        <p>No workflow definitions available.</p>
-    {% else %}
-        <ul>
-            {% for defn in definitions %}
-                <li class="wip-list-item">
-                    <h2>{{ defn.name }}</h2>
-                    <p>{{ defn.description or "No description." }}</p>
-                    <p><strong>Tasks:</strong> {{ ", ".join(defn.task_names) or "None" }}</p>
-                    <form action="/workflow-instances" method="post" style="margin-top:10px;" data-secure="true">
-                        <input type="hidden" name="definition_id" value="{{ defn.id }}">
-                        <button type="submit" class="action-button create-wip-link">Start '{{ defn.name }}'</button>
-                    </form>
-                    <a href="/workflow-definitions/edit/{{ defn.id }}" class="action-button" style="background-color: #f6ad55; margin-left: 10px;">Edit</a>
-                    <form action="/workflow-definitions/confirm-delete-workflow-definition/{{ defn.id }}" method="get" style="display:inline; margin-left: 10px;">
-                        <button type="submit" class="action-button cancel">Delete</button>
-                    </form>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
-    <a href="/" class="back-link" style="margin-top:20px;">← Back to Home</a>
-    <a href="/workflow-definitions/create" class="action-button" style="margin-top:20px;">Create New Checklist Template</a>
+<h1>Available Workflow Definitions</h1>
+{% if not definitions %}
+<p>No workflow definitions available.</p>
+{% else %}
+<ul>
+    {% for defn in definitions %}
+    <li class="wip-list-item">
+        <h2>{{ defn.name }}</h2>
+        <p>{{ defn.description or "No description." }}</p>
+        <p><strong>Tasks:</strong> {{ ", ".join(defn.task_names) or "None" }}</p>
+        <form action="/workflow-instances" method="post" style="margin-top:10px;" data-secure="true">
+            <input type="hidden" name="definition_id" value="{{ defn.id }}">
+            <button type="submit" class="action-button create-wip-link">Start '{{ defn.name }}'</button>
+        </form>
+        <a href="/workflow-definitions/edit/{{ defn.id }}" class="action-button"
+           style="background-color: #f6ad55; margin-left: 10px;">Edit</a>
+        <form action="/workflow-definitions/confirm-delete-workflow-definition/{{ defn.id }}" method="get"
+              style="display:inline; margin-left: 10px;">
+            <button type="submit" class="action-button cancel">Delete</button>
+        </form>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+<a href="/" class="back-link" style="margin-top:20px;">← Back to Home</a>
+<a href="/workflow-definitions/create" class="action-button" style="margin-top:20px;">Create New Checklist Template</a>
 {% endblock %}

--- a/app/templates/workflow_instance.html
+++ b/app/templates/workflow_instance.html
@@ -1,48 +1,51 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Workflow: {{ instance.name }}</h1>
-    <div class="workflow-details">
-        <p><strong>ID:</strong> {{ instance.id }}</p>
-        <p><strong>Status:</strong> {{ instance.status.upper() }}</p>
-        <p><strong>Created At:</strong> {{ instance.created_at.isoformat() }}</p>
-        <h2>Tasks:</h2>
-        {% if not tasks %}
-            <p>No tasks available for this workflow.</p>
-        {% else %}
-            <ul>
-                {% for task in tasks %}
-                    <li class="task-item" style="margin-bottom:10px;">
-                        <p><strong>Task:</strong> {{ task.name }} - {{ task.status.upper() }}</p>
-                        {% if task.status == "pending" %}
-                            <form action="/task-instances/{{ task.id }}/complete" method="post" style="display:inline; margin-left:10px;">
-                                <button type="submit" class="action-button submit">Mark Complete</button>
-                            </form>
-                        {% elif task.status == "completed" %}
-                            <form action="/task-instances/{{ task.id }}/undo-complete" method="post" style="display:inline; margin-left:10px;">
-                                <button type="submit" class="button is-info is-small">Undo Complete</button>
-                            </form>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-        {% if instance.status == "completed" %}
-            <p style="color: green; font-weight: bold; font-size:1.2em; margin-top:15px;">🎉 Workflow Complete!</p>
-        {% endif %}
-
-        {% if instance.status == "active" %}
-            <form action="/workflow-instances/{{ instance.id }}/archive" method="post" style="margin-top:15px;">
-                <button type="submit" class="action-button">Archive Workflow</button>
+<h1>Workflow: {{ instance.name }}</h1>
+<div class="workflow-details">
+    <p><strong>ID:</strong> {{ instance.id }}</p>
+    <p><strong>Status:</strong> {{ instance.status.upper() }}</p>
+    <p><strong>Created At:</strong> {{ instance.created_at.isoformat() }}</p>
+    <h2>Tasks:</h2>
+    {% if not tasks %}
+    <p>No tasks available for this workflow.</p>
+    {% else %}
+    <ul>
+        {% for task in tasks %}
+        <li class="task-item" style="margin-bottom:10px;">
+            <p><strong>Task:</strong> {{ task.name }} - {{ task.status.upper() }}</p>
+            {% if task.status == "pending" %}
+            <form action="/task-instances/{{ task.id }}/complete" method="post"
+                  style="display:inline; margin-left:10px;">
+                <button type="submit" class="action-button submit">Mark Complete</button>
             </form>
-        {% endif %}
-
-        {% if instance.status == "archived" %}
-            <form action="/workflow-instances/{{ instance.id }}/unarchive" method="post" style="margin-top:15px;">
-                <button type="submit" class="action-button">Unarchive Workflow</button>
+            {% elif task.status == "completed" %}
+            <form action="/task-instances/{{ task.id }}/undo-complete" method="post"
+                  style="display:inline; margin-left:10px;">
+                <button type="submit" class="button is-info is-small">Undo Complete</button>
             </form>
-        {% endif %}
-    </div>
-    <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Workflow Definitions</a>
-    <a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% if instance.status == "completed" %}
+    <p style="color: green; font-weight: bold; font-size:1.2em; margin-top:15px;">🎉 Workflow Complete!</p>
+    {% endif %}
+
+    {% if instance.status == "active" %}
+    <form action="/workflow-instances/{{ instance.id }}/archive" method="post" style="margin-top:15px;">
+        <button type="submit" class="action-button">Archive Workflow</button>
+    </form>
+    {% endif %}
+
+    {% if instance.status == "archived" %}
+    <form action="/workflow-instances/{{ instance.id }}/unarchive" method="post" style="margin-top:15px;">
+        <button type="submit" class="action-button">Unarchive Workflow</button>
+    </form>
+    {% endif %}
+</div>
+<a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Workflow
+    Definitions</a>
+<a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
 {% endblock %}

--- a/app/templates/workflow_instance.html
+++ b/app/templates/workflow_instance.html
@@ -36,6 +36,12 @@
                 <button type="submit" class="action-button">Archive Workflow</button>
             </form>
         {% endif %}
+
+        {% if instance.status == "archived" %}
+            <form action="/workflow-instances/{{ instance.id }}/unarchive" method="post" style="margin-top:15px;">
+                <button type="submit" class="action-button">Unarchive Workflow</button>
+            </form>
+        {% endif %}
     </div>
     <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Workflow Definitions</a>
     <a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>

--- a/app/templating.py
+++ b/app/templating.py
@@ -1,4 +1,5 @@
 from fastapi.templating import Jinja2Templates
 
+
 def get_templates() -> Jinja2Templates:
     return Jinja2Templates(directory="app/templates")

--- a/app/tests/test_api_endpoints.py
+++ b/app/tests/test_api_endpoints.py
@@ -1,25 +1,26 @@
-import pytest
-import sys
 import os
-import json
-from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, MagicMock, ANY
+import sys
 from datetime import date
+from unittest.mock import AsyncMock, MagicMock, ANY
+
+import pytest
+from fastapi.testclient import TestClient
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from app.db_models import Base
 from app.main import app
-from app.database import get_db, engine # get_db might not be directly used by these new tests
-from app.dependencies import get_workflow_service, get_html_renderer # For overriding
-from app.services import WorkflowService # For spec
-from app.core.html_renderer import HtmlRendererInterface # For spec
+from app.database import get_db, engine  # get_db might not be directly used by these new tests
+from app.dependencies import get_workflow_service, get_html_renderer  # For overriding
+from app.services import WorkflowService  # For spec
+from app.core.html_renderer import HtmlRendererInterface  # For spec
 from app.core.security import AuthenticatedUser, get_current_active_user
-from app.db_models.enums import WorkflowStatus # For test cases
+from app.db_models.enums import WorkflowStatus  # For test cases
 
 # Test client - can be initialized per test or per module if state is managed
-client = TestClient(app) # Will re-initialize client in fixture for overrides
+client = TestClient(app)  # Will re-initialize client in fixture for overrides
 
 # Mock user for authentication
 mock_user = AuthenticatedUser(user_id="test_user", username="testuser", email="test@example.com")
+
 
 # Fixture to setup and teardown the database
 @pytest.fixture(scope="function")
@@ -32,12 +33,15 @@ def db_session():
     transaction.rollback()
     connection.close()
 
+
 # Mock the get_current_active_user dependency
 def override_get_current_active_user():
     return mock_user
 
+
 # Override the dependency in the app for testing
 app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+
 
 @pytest.mark.asyncio
 async def test_list_workflow_definitions(db_session):
@@ -97,7 +101,6 @@ async def test_list_workflow_definitions_with_name_filter(db_session):
         assert "test workflow" in d["name"].lower()
         assert "another workflow beta" not in d["name"].lower()
 
-
     # Act: Filter by a name that should not match anything
     response_no_match = client.get("/api/workflow-definitions?name=NonExistentName")
 
@@ -119,7 +122,7 @@ async def test_list_workflow_definitions_with_name_filter(db_session):
     assert len(all_defs) >= 3
     all_returned_ids = {d["id"] for d in all_defs}
     assert id_alpha in all_returned_ids
-    assert response_beta.json()["id"] in all_returned_ids # Get id_beta here
+    assert response_beta.json()["id"] in all_returned_ids  # Get id_beta here
     assert id_gamma in all_returned_ids
 
 
@@ -139,6 +142,7 @@ async def test_create_workflow_definition(db_session):
     assert response.status_code == 201  # Created
     assert response.json()["name"] == "Test Workflow"
 
+
 @pytest.mark.asyncio
 async def test_create_workflow_definition_invalid_data(db_session):
     # Arrange
@@ -153,6 +157,7 @@ async def test_create_workflow_definition_invalid_data(db_session):
 
     # Assert
     assert response.status_code == 400  # Bad request due to validation error
+
 
 @pytest.mark.asyncio
 async def test_edit_workflow_definition(db_session):
@@ -180,6 +185,7 @@ async def test_edit_workflow_definition(db_session):
     assert response.status_code == 200
     assert response.json()["name"] == "Updated Workflow"
 
+
 @pytest.mark.asyncio
 async def test_edit_workflow_definition_not_found(db_session):
     # Arrange
@@ -194,6 +200,7 @@ async def test_edit_workflow_definition_not_found(db_session):
 
     # Assert
     assert response.status_code == 404  # Not found
+
 
 @pytest.mark.asyncio
 async def test_delete_workflow_definition(db_session):
@@ -213,6 +220,7 @@ async def test_delete_workflow_definition(db_session):
     # Assert
     assert response.status_code == 204  # No content after successful deletion
 
+
 @pytest.mark.asyncio
 async def test_delete_workflow_definition_not_found(db_session):
     # Act
@@ -220,6 +228,7 @@ async def test_delete_workflow_definition_not_found(db_session):
 
     # Assert
     assert response.status_code == 404  # Not found
+
 
 @pytest.mark.asyncio
 async def test_create_workflow_instance(db_session):
@@ -245,6 +254,7 @@ async def test_create_workflow_instance(db_session):
     assert response.status_code == 201  # Created
     assert response.json()["workflow_definition_id"] == definition_id
 
+
 @pytest.mark.asyncio
 async def test_create_workflow_instance_invalid_definition(db_session):
     # Arrange
@@ -257,6 +267,7 @@ async def test_create_workflow_instance_invalid_definition(db_session):
 
     # Assert
     assert response.status_code == 400  # Bad request due to invalid definition ID
+
 
 @pytest.mark.asyncio
 async def test_get_workflow_instance(db_session):
@@ -286,6 +297,7 @@ async def test_get_workflow_instance(db_session):
     assert "tasks" in response.json()
     assert response.json()["instance"]["id"] == instance_id
 
+
 @pytest.mark.asyncio
 async def test_get_workflow_instance_not_found(db_session):
     # Act
@@ -293,6 +305,7 @@ async def test_get_workflow_instance_not_found(db_session):
 
     # Assert
     assert response.status_code == 404  # Not found
+
 
 @pytest.mark.asyncio
 async def test_complete_task(db_session):
@@ -325,6 +338,7 @@ async def test_complete_task(db_session):
     assert response.status_code == 200
     assert response.json()["status"] == "completed"
 
+
 @pytest.mark.asyncio
 async def test_complete_task_not_found(db_session):
     # Act
@@ -332,6 +346,7 @@ async def test_complete_task_not_found(db_session):
 
     # Assert
     assert response.status_code == 400  # Bad request due to task not found
+
 
 @pytest.mark.asyncio
 async def test_list_user_workflows(db_session):
@@ -370,11 +385,11 @@ async def test_list_user_workflows(db_session):
 def mock_dependencies_for_my_workflows(monkeypatch):
     # Create fresh mocks for each test run using this fixture
     mock_service = MagicMock(spec=WorkflowService)
-    mock_service.list_instances_for_user = AsyncMock(return_value=[]) # Default empty list
+    mock_service.list_instances_for_user = AsyncMock(return_value=[])  # Default empty list
 
     mock_renderer_instance = MagicMock(spec=HtmlRendererInterface)
-    mock_renderer_instance.render = AsyncMock(return_value="Mocked HTML") # Default render response
-    
+    mock_renderer_instance.render = AsyncMock(return_value="Mocked HTML")  # Default render response
+
     # Store mocks to access them in tests if needed (e.g. via request.app.state or by returning them)
     # For simplicity here, we'll rely on them being the ones used by the overridden dependencies.
     # If we needed to access the mocks directly from the test function, this fixture would return them.
@@ -383,10 +398,10 @@ def mock_dependencies_for_my_workflows(monkeypatch):
     # This is cleaner than globally modifying app.dependency_overrides for specific tests.
     monkeypatch.setitem(app.dependency_overrides, get_workflow_service, lambda: mock_service)
     monkeypatch.setitem(app.dependency_overrides, get_html_renderer, lambda: mock_renderer_instance)
-    
+
     # Yield the mocks if tests need to directly inspect them, e.g., for call counts after request
     yield mock_service, mock_renderer_instance
-    
+
     # Clean up overrides after the test
     monkeypatch.delitem(app.dependency_overrides, get_workflow_service, raising=False)
     monkeypatch.delitem(app.dependency_overrides, get_html_renderer, raising=False)
@@ -394,22 +409,22 @@ def mock_dependencies_for_my_workflows(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_my_workflows_no_query_parameters(mock_dependencies_for_my_workflows):
-    client = TestClient(app) # Fresh client to ensure overrides are clean if not using monkeypatch correctly
+    client = TestClient(app)  # Fresh client to ensure overrides are clean if not using monkeypatch correctly
     mock_service, mock_renderer = mock_dependencies_for_my_workflows
 
     response = client.get("/my-workflows")
     assert response.status_code == 200
 
     mock_service.list_instances_for_user.assert_called_once_with(
-        user_id=mock_user.user_id, # from global mock_user via override_get_current_active_user
+        user_id=mock_user.user_id,  # from global mock_user via override_get_current_active_user
         created_at_date=date.today(),
         status=WorkflowStatus.active
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
-        ANY, # request object
+        ANY,  # request object
         {
-            "instances": [], # Default return from mock_service.list_instances_for_user
+            "instances": [],  # Default return from mock_service.list_instances_for_user
             "selected_created_at": date.today().isoformat(),
             "selected_status": "active",
             "workflow_statuses": [s.value for s in WorkflowStatus]
@@ -423,24 +438,25 @@ async def test_my_workflows_no_query_parameters(mock_dependencies_for_my_workflo
 OWNER_USER_ID_FOR_ARCHIVE = "owner_archive_api"
 OTHER_USER_ID_FOR_ARCHIVE = "other_archive_api"
 
+
 @pytest.fixture
-def client_as_user_archive(monkeypatch): # Renamed to avoid conflict if other client_as_user exists
+def client_as_user_archive(monkeypatch):  # Renamed to avoid conflict if other client_as_user exists
     clients_created = []
     original_override = app.dependency_overrides.get(get_current_active_user)
 
     def _client_as_user(user: AuthenticatedUser = None):
         if user:
             monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: user)
-        else: # No user / unauthenticated
+        else:  # No user / unauthenticated
             if get_current_active_user in app.dependency_overrides:
                 monkeypatch.delitem(app.dependency_overrides, get_current_active_user)
-        
+
         client = TestClient(app)
-        clients_created.append(client) # Keep track if needed, though TestClient instances are independent
+        clients_created.append(client)  # Keep track if needed, though TestClient instances are independent
         return client
 
     yield _client_as_user
-    
+
     # Cleanup: restore original override or remove if it was added by this fixture
     if original_override:
         monkeypatch.setitem(app.dependency_overrides, get_current_active_user, original_override)
@@ -451,10 +467,10 @@ def client_as_user_archive(monkeypatch): # Renamed to avoid conflict if other cl
 # Helper to create a workflow definition and instance for testing archive functionality
 # Uses direct DB manipulation for status to simplify setup and avoid complex API chaining for status changes.
 def create_test_workflow_instance_for_archive(
-    client_for_creation: TestClient, # Client authenticated as the user who should own the instance
-    owner_user_id: str, 
-    status: WorkflowStatus = WorkflowStatus.active,
-    def_name_suffix: str = "" 
+        client_for_creation: TestClient,  # Client authenticated as the user who should own the instance
+        owner_user_id: str,
+        status: WorkflowStatus = WorkflowStatus.active,
+        def_name_suffix: str = ""
 ) -> dict:
     definition_data = {
         "name": f"Archive Test Def {def_name_suffix}",
@@ -471,7 +487,7 @@ def create_test_workflow_instance_for_archive(
     assert create_inst_response.status_code == 201
     instance_id = create_inst_response.json()["id"]
     created_instance = create_inst_response.json()
-    
+
     # Manually update status in DB if needed, as API create defaults to 'active' and user_id from auth
     # The instance created via API will have user_id from client_for_creation's auth.
     # We need to ensure this matches owner_user_id passed.
@@ -482,35 +498,37 @@ def create_test_workflow_instance_for_archive(
         # Use a new DB session for this direct modification
         temp_db_session = next(get_db())
         try:
-            db_instance = temp_db_session.query(WorkflowInstanceORM).filter(WorkflowInstanceORM.id == instance_id).first()
+            db_instance = temp_db_session.query(WorkflowInstanceORM).filter(
+                WorkflowInstanceORM.id == instance_id).first()
             assert db_instance is not None
-            db_instance.status = status # This should be the WorkflowStatus enum member, not string
+            db_instance.status = status  # This should be the WorkflowStatus enum member, not string
             temp_db_session.commit()
             temp_db_session.refresh(db_instance)
             # Update the created_instance dict with the new status
             created_instance = client_for_creation.get(f"/api/workflow-instances/{instance_id}").json()["instance"]
         finally:
             temp_db_session.close()
-            
+
     return created_instance
 
 
 @pytest.mark.asyncio
 async def test_archive_instance_success(db_session, client_as_user_archive, monkeypatch):
     owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive", email="owner@archive.com")
-    
+
     # Client for setup, authenticated as owner
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active, def_name_suffix="success")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active,
+                                                         def_name_suffix="success")
     instance_id = instance["id"]
-    
+
     # Client for the actual test call, also authenticated as owner
-    client = client_as_user_archive(owner) # This will re-apply the override via monkeypatch
+    client = client_as_user_archive(owner)  # This will re-apply the override via monkeypatch
 
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
 
-    assert response.status_code == 303 # Redirect
+    assert response.status_code == 303  # Redirect
     assert response.headers["location"] == f"/workflow-instances/{instance_id}"
 
     # Verify status using the API (client is still authenticated as owner)
@@ -521,47 +539,52 @@ async def test_archive_instance_success(db_session, client_as_user_archive, monk
 
 @pytest.mark.asyncio
 async def test_archive_instance_not_authenticated(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_auth", email="owner_auth@archive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_auth",
+                              email="owner_auth@archive.com")
+
     # Setup client for creating instance (as owner)
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active, def_name_suffix="notauth")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active,
+                                                         def_name_suffix="notauth")
     instance_id = instance["id"]
 
     # Client for test is unauthenticated
-    client = client_as_user_archive(None) 
-    
+    client = client_as_user_archive(None)
+
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
 
-    assert response.status_code == 307 # Temporary Redirect to login as per FastAPI default for unauthenticated HTML form posts
-    assert "/login" in response.headers["location"].lower() 
+    assert response.status_code == 307  # Temporary Redirect to login as per FastAPI default for unauthenticated HTML form posts
+    assert "/login" in response.headers["location"].lower()
+
 
 @pytest.mark.asyncio
 async def test_archive_instance_other_user(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_other", email="owner_other@archive.com")
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_other",
+                              email="owner_other@archive.com")
     other = AuthenticatedUser(user_id=OTHER_USER_ID_FOR_ARCHIVE, username="other_archive", email="other@archive.com")
 
     # Setup client for creating instance (as owner)
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active, def_name_suffix="otheruser")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active,
+                                                         def_name_suffix="otheruser")
     instance_id = instance["id"]
 
     # Client for test is authenticated as other_user
     client = client_as_user_archive(other)
 
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
-    
+
     # Based on the endpoint logic, if service.archive_workflow_instance returns None (e.g. due to user mismatch)
     # it then tries to fetch the instance (service.get_workflow_instance_with_tasks) which would also fail for other_user
     # leading to a 404 from create_message_page.
-    assert response.status_code == 404 
+    assert response.status_code == 404
     assert "not found or you do not have permission to view it" in response.text.lower()
 
     # Verify instance in DB is NOT archived (check via API as owner)
-    monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner) # Switch auth to owner
-    owner_client = TestClient(app) # New client with owner auth
+    monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)  # Switch auth to owner
+    owner_client = TestClient(app)  # New client with owner auth
     original_instance_response = owner_client.get(f"/api/workflow-instances/{instance_id}")
     assert original_instance_response.status_code == 200
     assert original_instance_response.json()["instance"]["status"] == WorkflowStatus.active.value
@@ -569,49 +592,56 @@ async def test_archive_instance_other_user(db_session, client_as_user_archive, m
 
 @pytest.mark.asyncio
 async def test_archive_instance_already_completed(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_completed", email="owner_completed@archive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_completed",
+                              email="owner_completed@archive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
-    setup_client = TestClient(app) # Client for setup, authenticated as owner
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.completed, def_name_suffix="completed")
+    setup_client = TestClient(app)  # Client for setup, authenticated as owner
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.completed,
+                                                         def_name_suffix="completed")
     instance_id = instance["id"]
-    
-    client = client_as_user_archive(owner) # Client for test, also as owner
+
+    client = client_as_user_archive(owner)  # Client for test, also as owner
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
 
-    assert response.status_code == 400 # Bad Request
+    assert response.status_code == 400  # Bad Request
     assert "cannot archive a workflow instance that is already completed" in response.text.lower()
+
 
 @pytest.mark.asyncio
 async def test_archive_instance_non_existent(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_nonexist", email="owner_nonexist@archive.com")
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_nonexist",
+                              email="owner_nonexist@archive.com")
     client = client_as_user_archive(owner)
     instance_id = "non_existent_instance_id_12345abc"
 
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
 
-    assert response.status_code == 404 # Not Found
+    assert response.status_code == 404  # Not Found
     # Message comes from service.archive returning None, then router trying get_workflow_instance_with_tasks, which also fails for non-existent.
     assert f"workflow instance with id '{instance_id}' not found or you do not have permission to view it" in response.text.lower()
 
+
 @pytest.mark.asyncio
 async def test_archive_instance_already_archived(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_already", email="owner_already@archive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_ARCHIVE, username="owner_archive_already",
+                              email="owner_already@archive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.archived, def_name_suffix="alreadyarchived")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.archived,
+                                                         def_name_suffix="alreadyarchived")
     instance_id = instance["id"]
-    
+
     client = client_as_user_archive(owner)
     response = client.post(f"/workflow-instances/{instance_id}/archive", follow_redirects=False)
 
     # The service method `archive_workflow_instance` returns the instance if already archived.
     # The router endpoint then treats this as a success and redirects.
-    assert response.status_code == 303 
+    assert response.status_code == 303
     assert response.headers["location"] == f"/workflow-instances/{instance_id}"
 
-    # Verify status is still ARCHIVED
+    # Verify status is still archived
     updated_instance_response = client.get(f"/api/workflow-instances/{instance_id}")
     assert updated_instance_response.status_code == 200
     assert updated_instance_response.json()["instance"]["status"] == WorkflowStatus.archived.value
@@ -623,101 +653,119 @@ async def test_archive_instance_already_archived(db_session, client_as_user_arch
 OWNER_USER_ID_FOR_UNARCHIVE = "owner_unarchive_api"
 OTHER_USER_ID_FOR_UNARCHIVE = "other_unarchive_api"
 
+
 @pytest.mark.asyncio
 async def test_unarchive_instance_success(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive", email="owner@unarchive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive",
+                              email="owner@unarchive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.ARCHIVED, def_name_suffix="unarchive_success")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.archived,
+                                                         def_name_suffix="unarchive_success")
     instance_id = instance["id"]
-    
+
     client = client_as_user_archive(owner)
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
 
-    assert response.status_code == 303 # Redirect
+    assert response.status_code == 303  # Redirect
     assert response.headers["location"] == f"/workflow-instances/{instance_id}"
 
     updated_instance_response = client.get(f"/api/workflow-instances/{instance_id}")
     assert updated_instance_response.status_code == 200
     assert updated_instance_response.json()["instance"]["status"] == WorkflowStatus.active.value
 
+
 @pytest.mark.asyncio
 async def test_unarchive_instance_not_authenticated(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_auth", email="owner_unauth@unarchive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_auth",
+                              email="owner_unauth@unarchive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.ARCHIVED, def_name_suffix="unarchive_notauth")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.archived,
+                                                         def_name_suffix="unarchive_notauth")
     instance_id = instance["id"]
 
-    client = client_as_user_archive(None) # Unauthenticated client
+    client = client_as_user_archive(None)  # Unauthenticated client
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
 
-    assert response.status_code == 307 # Redirect to login
+    assert response.status_code == 307  # Redirect to login
     assert "/login" in response.headers["location"].lower()
+
 
 @pytest.mark.asyncio
 async def test_unarchive_instance_other_user(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_other", email="owner_other@unarchive.com")
-    other = AuthenticatedUser(user_id=OTHER_USER_ID_FOR_UNARCHIVE, username="other_unarchive", email="other@unarchive.com")
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_other",
+                              email="owner_other@unarchive.com")
+    other = AuthenticatedUser(user_id=OTHER_USER_ID_FOR_UNARCHIVE, username="other_unarchive",
+                              email="other@unarchive.com")
 
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.ARCHIVED, def_name_suffix="unarchive_other_user")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.archived,
+                                                         def_name_suffix="unarchive_other_user")
     instance_id = instance["id"]
 
-    client = client_as_user_archive(other) # Authenticated as 'other' user
+    client = client_as_user_archive(other)  # Authenticated as 'other' user
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
-    
-    assert response.status_code == 404 # Service returns None, router shows 404 if instance not found for user
+
+    assert response.status_code == 404  # Service returns None, router shows 404 if instance not found for user
     assert "not found or you do not have permission to view it" in response.text.lower()
 
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     owner_client = TestClient(app)
     original_instance_response = owner_client.get(f"/api/workflow-instances/{instance_id}")
-    assert original_instance_response.json()["instance"]["status"] == WorkflowStatus.ARCHIVED.value # Should still be archived
+    assert original_instance_response.json()["instance"][
+               "status"] == WorkflowStatus.archived.value  # Should still be archived
+
 
 @pytest.mark.asyncio
 async def test_unarchive_instance_not_archived_state_active(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_active", email="owner_active@unarchive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_active",
+                              email="owner_active@unarchive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active, def_name_suffix="unarchive_already_active")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.active,
+                                                         def_name_suffix="unarchive_already_active")
     instance_id = instance["id"]
-    
+
     client = client_as_user_archive(owner)
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
 
-    assert response.status_code == 400 # Bad Request
+    assert response.status_code == 400  # Bad Request
     assert "cannot unarchive a workflow instance that is not currently archived" in response.text.lower()
+
 
 @pytest.mark.asyncio
 async def test_unarchive_instance_not_archived_state_completed(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_completed", email="owner_completed@unarchive.com")
-    
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_completed",
+                              email="owner_completed@unarchive.com")
+
     monkeypatch.setitem(app.dependency_overrides, get_current_active_user, lambda: owner)
     setup_client = TestClient(app)
-    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.completed, def_name_suffix="unarchive_already_completed")
+    instance = create_test_workflow_instance_for_archive(setup_client, owner.user_id, status=WorkflowStatus.completed,
+                                                         def_name_suffix="unarchive_already_completed")
     instance_id = instance["id"]
-    
+
     client = client_as_user_archive(owner)
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
 
-    assert response.status_code == 400 # Bad Request
+    assert response.status_code == 400  # Bad Request
     assert "cannot unarchive a workflow instance that is not currently archived" in response.text.lower()
 
 
 @pytest.mark.asyncio
 async def test_unarchive_instance_non_existent(db_session, client_as_user_archive, monkeypatch):
-    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_nonexist", email="owner_nonexist@unarchive.com")
+    owner = AuthenticatedUser(user_id=OWNER_USER_ID_FOR_UNARCHIVE, username="owner_unarchive_nonexist",
+                              email="owner_nonexist@unarchive.com")
     client = client_as_user_archive(owner)
     instance_id = "non_existent_instance_for_unarchive"
 
     response = client.post(f"/workflow-instances/{instance_id}/unarchive", follow_redirects=False)
 
-    assert response.status_code == 404 # Not Found
+    assert response.status_code == 404  # Not Found
     assert f"workflow instance with id '{instance_id}' not found or you do not have permission to view it" in response.text.lower()
 
 
@@ -725,7 +773,7 @@ async def test_unarchive_instance_non_existent(db_session, client_as_user_archiv
 async def test_my_workflows_with_created_at(mock_dependencies_for_my_workflows):
     client = TestClient(app)
     mock_service, mock_renderer = mock_dependencies_for_my_workflows
-    
+
     test_date_str = "2023-01-15"
     test_date_obj = date(2023, 1, 15)
 
@@ -747,6 +795,7 @@ async def test_my_workflows_with_created_at(mock_dependencies_for_my_workflows):
             "workflow_statuses": [s.value for s in WorkflowStatus]
         }
     )
+
 
 @pytest.mark.asyncio
 async def test_my_workflows_with_status(mock_dependencies_for_my_workflows):
@@ -772,18 +821,19 @@ async def test_my_workflows_with_status(mock_dependencies_for_my_workflows):
         }
     )
 
+
 @pytest.mark.asyncio
 async def test_my_workflows_with_all_statuses(mock_dependencies_for_my_workflows):
     client = TestClient(app)
     mock_service, mock_renderer = mock_dependencies_for_my_workflows
 
-    response = client.get("/my-workflows?status=") # Empty status for "All Statuses"
+    response = client.get("/my-workflows?status=")  # Empty status for "All Statuses"
     assert response.status_code == 200
 
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=None # Service receives None for "All Statuses"
+        status=None  # Service receives None for "All Statuses"
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -791,10 +841,11 @@ async def test_my_workflows_with_all_statuses(mock_dependencies_for_my_workflows
         {
             "instances": [],
             "selected_created_at": date.today().isoformat(),
-            "selected_status": "", # Template receives empty string
+            "selected_status": "",  # Template receives empty string
             "workflow_statuses": [s.value for s in WorkflowStatus]
         }
     )
+
 
 @pytest.mark.asyncio
 async def test_my_workflows_with_created_at_and_status(mock_dependencies_for_my_workflows):
@@ -823,6 +874,7 @@ async def test_my_workflows_with_created_at_and_status(mock_dependencies_for_my_
         }
     )
 
+
 @pytest.mark.asyncio
 async def test_my_workflows_invalid_created_at(mock_dependencies_for_my_workflows):
     client = TestClient(app)
@@ -848,6 +900,7 @@ async def test_my_workflows_invalid_created_at(mock_dependencies_for_my_workflow
         }
     )
 
+
 @pytest.mark.asyncio
 async def test_my_workflows_invalid_status(mock_dependencies_for_my_workflows):
     client = TestClient(app)
@@ -860,7 +913,7 @@ async def test_my_workflows_invalid_status(mock_dependencies_for_my_workflows):
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=WorkflowStatus.active # Default for invalid status string
+        status=WorkflowStatus.active  # Default for invalid status string
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -868,7 +921,7 @@ async def test_my_workflows_invalid_status(mock_dependencies_for_my_workflows):
         {
             "instances": [],
             "selected_created_at": date.today().isoformat(),
-            "selected_status": "active", # Reflects the default used
+            "selected_status": "active",  # Reflects the default used
             "workflow_statuses": [s.value for s in WorkflowStatus]
         }
     )

--- a/app/tests/test_repository.py
+++ b/app/tests/test_repository.py
@@ -1,24 +1,21 @@
-import pytest
-import sys
 import os
+import sys
 from datetime import date as DateObject
+
+import pytest
 
 # Add the project root to sys.path to ensure 'app' module can be found
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 from app.db_models import Base
 from app.repository import PostgreSQLWorkflowRepository, DefinitionNotFoundError, DefinitionInUseError
 from app.models import WorkflowDefinition, TaskInstance, WorkflowInstance
 from app.db_models.enums import WorkflowStatus, TaskStatus
 from app.db_models import WorkflowInstance as WorkflowInstanceORM
 
-import unittest
-from unittest.mock import MagicMock, call, PropertyMock
+from unittest.mock import MagicMock
 # Setup for PostgreSQL database for testing
 # Use environment variables or a test-specific configuration for the database connection
-import os
-from datetime import datetime # Added for mock ORM objects
+from datetime import datetime  # Added for mock ORM objects
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from app.config import DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME
@@ -45,6 +42,7 @@ SQLALCHEMY_DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}
 engine = create_engine(SQLALCHEMY_DATABASE_URL, echo=True)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+
 @pytest.fixture(scope="function")
 def db_session():
     # Create the test database tables
@@ -55,6 +53,7 @@ def db_session():
     session.close()
     # Optionally drop tables after tests if needed, though this can be slow
     Base.metadata.drop_all(bind=engine)
+
 
 @pytest.mark.asyncio
 async def test_list_workflow_definitions(db_session):
@@ -87,6 +86,7 @@ async def test_list_workflow_definitions(db_session):
     assert result[0].task_names == ["Task 1", "Task 2"]
     assert result[1].task_names == ["Task 3", "Task 4"]
 
+
 @pytest.mark.asyncio
 async def test_get_workflow_definition_by_id(db_session):
     # Arrange
@@ -110,6 +110,7 @@ async def test_get_workflow_definition_by_id(db_session):
     assert result.name == "Test Workflow"
     assert result.description == "A test workflow definition"
     assert result.task_names == ["Task 1", "Task 2"]
+
 
 @pytest.mark.asyncio
 async def test_get_workflow_definition_by_id_not_found(db_session):
@@ -136,7 +137,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         mock_db_session.query.return_value = mock_query_chain
         mock_query_chain.filter.return_value = mock_query_chain
         mock_query_chain.order_by.return_value = mock_query_chain
-        
+
         # Mock ORM instance data
         mock_orm_instance = WorkflowInstanceORM(
             id="wf1",
@@ -153,7 +154,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
 
         # Assertions
         mock_db_session.query.assert_called_once_with(WorkflowInstanceORM)
-        
+
         # Check filter calls
         # The first filter is for user_id
         # No other filters should be applied for this test case
@@ -161,11 +162,11 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         # call_args_list[0] should be the user_id filter
         # and there should be only one call to filter in this specific scenario setup (before order_by)
         # However, the implementation applies filters sequentially.
-        
+
         # Let's verify the structure of the calls.
         # The actual filter calls are on the instance returned by query.filter().filter()...
         # So, mock_query_chain.filter is called.
-        
+
         # First call to filter is for user_id
         actual_call = mock_query_chain.filter.call_args_list[0]
         # The argument to filter is a SQLAlchemy binary expression.
@@ -173,7 +174,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         # This is the tricky part with SQLAlchemy expressions.
         # For now, let's check it was called. A more robust check would compare the expression.
         assert str(actual_call[0][0]) == str(WorkflowInstanceORM.user_id == "user123")
-        assert mock_query_chain.filter.call_count == 1 # Only user_id filter
+        assert mock_query_chain.filter.call_count == 1  # Only user_id filter
 
         # Ensure order_by is called correctly
         # This also involves comparing SQLAlchemy expressions.
@@ -181,7 +182,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         mock_query_chain.order_by.assert_called_once()
         order_by_call_arg = mock_query_chain.order_by.call_args[0][0]
         assert str(order_by_call_arg) == str(WorkflowInstanceORM.created_at.desc())
-        
+
         mock_query_chain.all.assert_called_once()
 
         assert len(results) == 1
@@ -196,7 +197,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         mock_db_session.query.return_value = mock_query_chain
         mock_query_chain.filter.return_value = mock_query_chain
         mock_query_chain.order_by.return_value = mock_query_chain
-        mock_query_chain.all.return_value = [] # Actual data not important for filter assertion
+        mock_query_chain.all.return_value = []  # Actual data not important for filter assertion
 
         repo = PostgreSQLWorkflowRepository(db_session=mock_db_session)
         test_date = DateObject(2023, 5, 15)
@@ -207,7 +208,7 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         assert mock_query_chain.filter.call_count == 2
         user_id_filter_call = mock_query_chain.filter.call_args_list[0]
         created_at_filter_call = mock_query_chain.filter.call_args_list[1]
-        
+
         assert str(user_id_filter_call[0][0]) == str(WorkflowInstanceORM.user_id == "user123")
         assert str(created_at_filter_call[0][0]) == str(WorkflowInstanceORM.created_at == test_date)
         mock_query_chain.order_by.assert_called_once()
@@ -269,11 +270,11 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         mock_db_session = MagicMock()
         mock_query_chain = MagicMock()
         mock_db_session.query.return_value = mock_query_chain
-        mock_query_chain.filter.return_value = mock_query_chain # filter returns itself
+        mock_query_chain.filter.return_value = mock_query_chain  # filter returns itself
         mock_query_chain.order_by.return_value = mock_query_chain
-        
+
         mock_orm_instance = WorkflowInstanceORM(
-            id="wf2", user_id="isolated_user", name="Isolated Workflow", 
+            id="wf2", user_id="isolated_user", name="Isolated Workflow",
             status=WorkflowStatus.active, created_at=datetime(2023, 1, 2, 12, 0, 0), workflow_definition_id="def2"
         )
         mock_query_chain.all.return_value = [mock_orm_instance]
@@ -281,29 +282,29 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         repo = PostgreSQLWorkflowRepository(db_session=mock_db_session)
         test_date = DateObject(2023, 7, 1)
         test_status = WorkflowStatus.pending
-        
+
         results = await repo.list_workflow_instances_by_user(
-            user_id="isolated_user", 
-            created_at_date=test_date, 
+            user_id="isolated_user",
+            created_at_date=test_date,
             status=test_status
         )
 
         mock_db_session.query.assert_called_once_with(WorkflowInstanceORM)
-        
+
         # Ensure the very first filter applied is for the user_id
-        assert mock_query_chain.filter.call_count == 3 # user_id, created_at, status
+        assert mock_query_chain.filter.call_count == 3  # user_id, created_at, status
         first_filter_call_arg = mock_query_chain.filter.call_args_list[0][0][0]
         assert str(first_filter_call_arg) == str(WorkflowInstanceORM.user_id == "isolated_user")
-        
+
         # Check other filters are also applied
         second_filter_call_arg = mock_query_chain.filter.call_args_list[1][0][0]
         assert str(second_filter_call_arg) == str(WorkflowInstanceORM.created_at == test_date)
-        
+
         third_filter_call_arg = mock_query_chain.filter.call_args_list[2][0][0]
         assert str(third_filter_call_arg) == str(WorkflowInstanceORM.status == test_status)
 
         mock_query_chain.order_by.assert_called_once()
-        
+
         assert len(results) == 1
         assert results[0].id == "wf2"
         assert results[0].user_id == "isolated_user"
@@ -315,16 +316,17 @@ class TestUnitPostgreSQLListWorkflowInstancesByUser:
         mock_db_session.query.return_value = mock_query_chain
         mock_query_chain.filter.return_value = mock_query_chain
         mock_query_chain.order_by.return_value = mock_query_chain
-        mock_query_chain.all.return_value = [] # No ORM objects returned
+        mock_query_chain.all.return_value = []  # No ORM objects returned
 
         repo = PostgreSQLWorkflowRepository(db_session=mock_db_session)
         results = await repo.list_workflow_instances_by_user(user_id="user_with_no_workflows")
 
         assert results == []
         mock_db_session.query.assert_called_once_with(WorkflowInstanceORM)
-        mock_query_chain.filter.assert_called_once() # User ID filter
+        mock_query_chain.filter.assert_called_once()  # User ID filter
         mock_query_chain.order_by.assert_called_once()
         mock_query_chain.all.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_create_workflow_definition(db_session):
@@ -353,6 +355,7 @@ async def test_create_workflow_definition(db_session):
     assert db_defn is not None
     assert db_defn.name == "Test Workflow"
     assert db_defn.task_names == ["Task 1", "Task 2"]
+
 
 @pytest.mark.asyncio
 async def test_update_workflow_definition(db_session):
@@ -388,6 +391,7 @@ async def test_update_workflow_definition(db_session):
     assert db_defn.name == "Updated Workflow"
     assert db_defn.task_names == ["Updated Task 1", "Updated Task 2"]
 
+
 @pytest.mark.asyncio
 async def test_update_workflow_definition_not_found(db_session):
     # Arrange
@@ -403,6 +407,7 @@ async def test_update_workflow_definition_not_found(db_session):
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_delete_workflow_definition(db_session):
@@ -425,6 +430,7 @@ async def test_delete_workflow_definition(db_session):
     db_defn = db_session.query(WorkflowDefinitionORM).filter(WorkflowDefinitionORM.id == "test_def_1").first()
     assert db_defn is None
 
+
 @pytest.mark.asyncio
 async def test_delete_workflow_definition_not_found(db_session):
     # Arrange
@@ -433,6 +439,7 @@ async def test_delete_workflow_definition_not_found(db_session):
     # Act & Assert
     with pytest.raises(DefinitionNotFoundError, match="Workflow Definition with ID 'non_existent_id' not found."):
         await repo.delete_workflow_definition("non_existent_id")
+
 
 @pytest.mark.asyncio
 async def test_delete_workflow_definition_in_use(db_session):
@@ -448,7 +455,7 @@ async def test_delete_workflow_definition_in_use(db_session):
     )
     db_session.add(defn)
     db_session.commit()
-    
+
     instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -461,8 +468,10 @@ async def test_delete_workflow_definition_in_use(db_session):
     db_session.commit()
 
     # Act & Assert
-    with pytest.raises(DefinitionInUseError, match="Cannot delete definition: It is currently used by 1 workflow instance\\(s\\)."):
+    with pytest.raises(DefinitionInUseError,
+                       match="Cannot delete definition: It is currently used by 1 workflow instance\\(s\\)."):
         await repo.delete_workflow_definition("test_def_1")
+
 
 @pytest.mark.asyncio
 async def test_get_workflow_instance_by_id(db_session):
@@ -478,7 +487,7 @@ async def test_get_workflow_instance_by_id(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -501,6 +510,7 @@ async def test_get_workflow_instance_by_id(db_session):
     assert result.status == WorkflowStatus.active
     assert result.user_id == "test_user"
 
+
 @pytest.mark.asyncio
 async def test_get_workflow_instance_by_id_not_found(db_session):
     # Arrange
@@ -511,6 +521,7 @@ async def test_get_workflow_instance_by_id_not_found(db_session):
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_create_workflow_instance(db_session):
@@ -525,7 +536,7 @@ async def test_create_workflow_instance(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     instance_data = WorkflowInstance(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -553,6 +564,7 @@ async def test_create_workflow_instance(db_session):
     assert db_instance.user_id == "test_user"
     assert db_instance.status == WorkflowStatus.active
 
+
 @pytest.mark.asyncio
 async def test_update_workflow_instance(db_session):
     # Arrange
@@ -567,7 +579,7 @@ async def test_update_workflow_instance(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -602,6 +614,7 @@ async def test_update_workflow_instance(db_session):
     assert db_instance.name == "Updated Workflow Instance"
     assert db_instance.status == WorkflowStatus.completed
 
+
 @pytest.mark.asyncio
 async def test_update_workflow_instance_not_found(db_session):
     # Arrange
@@ -620,6 +633,7 @@ async def test_update_workflow_instance_not_found(db_session):
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_list_workflow_instances_by_user(db_session):
@@ -649,7 +663,7 @@ async def test_list_workflow_instances_by_user(db_session):
     db_session.add(def2)
     db_session.add(def3)
     db_session.commit()
-    
+
     instance1 = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -688,6 +702,7 @@ async def test_list_workflow_instances_by_user(db_session):
     assert result[1].id == "test_wf_1"
     assert all(instance.user_id == "test_user" for instance in result)
 
+
 @pytest.mark.asyncio
 async def test_create_task_instance(db_session):
     # Arrange
@@ -702,7 +717,7 @@ async def test_create_task_instance(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     workflow_instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -740,6 +755,7 @@ async def test_create_task_instance(db_session):
     assert db_task.name == "Test Task"
     assert db_task.status == TaskStatus.pending
 
+
 @pytest.mark.asyncio
 async def test_get_tasks_for_workflow_instance(db_session):
     # Arrange
@@ -755,7 +771,7 @@ async def test_get_tasks_for_workflow_instance(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     workflow_instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -792,6 +808,7 @@ async def test_get_tasks_for_workflow_instance(db_session):
         assert task.order == i
         assert task.status == TaskStatus.pending
 
+
 @pytest.mark.asyncio
 async def test_get_tasks_for_workflow_instance_no_tasks(db_session):
     # Arrange
@@ -806,7 +823,7 @@ async def test_get_tasks_for_workflow_instance_no_tasks(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     workflow_instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -824,6 +841,7 @@ async def test_get_tasks_for_workflow_instance_no_tasks(db_session):
     # Assert
     assert len(result) == 0
 
+
 @pytest.mark.asyncio
 async def test_get_task_instance_by_id(db_session):
     # Arrange
@@ -839,7 +857,7 @@ async def test_get_task_instance_by_id(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     workflow_instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -872,6 +890,7 @@ async def test_get_task_instance_by_id(db_session):
     assert result.order == 0
     assert result.status == TaskStatus.pending
 
+
 @pytest.mark.asyncio
 async def test_get_task_instance_by_id_not_found(db_session):
     # Arrange
@@ -882,6 +901,7 @@ async def test_get_task_instance_by_id_not_found(db_session):
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_update_task_instance(db_session):
@@ -898,7 +918,7 @@ async def test_update_task_instance(db_session):
     )
     db_session.add(definition)
     db_session.commit()
-    
+
     workflow_instance = WorkflowInstanceORM(
         id="test_wf_1",
         workflow_definition_id="test_def_1",
@@ -943,6 +963,7 @@ async def test_update_task_instance(db_session):
     db_task = db_session.query(TaskInstanceORM).filter(TaskInstanceORM.id == "test_task_1").first()
     assert db_task.name == "Updated Test Task"
     assert db_task.status == TaskStatus.completed
+
 
 @pytest.mark.asyncio
 async def test_update_task_instance_not_found(db_session):

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -1,16 +1,17 @@
-import pytest
-import sys
 import os
-from unittest.mock import patch, MagicMock
-from fastapi import HTTPException, Request
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from jose import jwt, JWTError
-import time
 
 # Add the project root to sys.path to ensure 'app' module can be found
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from app.core.security import get_current_user, get_keycloak_public_keys, AuthenticatedUser, get_current_active_user
-from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM, KEYCLOAK_API_CLIENT_ID
+from app.core.security import get_current_user, AuthenticatedUser, get_current_active_user
+from app.config import KEYCLOAK_SERVER_URL, KEYCLOAK_REALM
 from app.main import app
 
 # Test client
@@ -73,6 +74,7 @@ MOCK_TOKEN_WRONG_AUDIENCE = jwt.encode(
 
 MOCK_TOKEN_INVALID = "invalid.token.string"
 
+
 # Mock get_keycloak_public_keys to avoid real HTTP calls during tests
 def mock_get_keycloak_public_keys():
     return {
@@ -88,6 +90,7 @@ def mock_get_keycloak_public_keys():
             }
         ]
     }
+
 
 # Mock jwt.decode to return predefined payloads based on token
 def mock_jwt_decode(token, key, algorithms, audience, issuer):
@@ -127,64 +130,70 @@ def mock_jwt_decode(token, key, algorithms, audience, issuer):
         }
     raise JWTError("Invalid token")
 
+
 @pytest.mark.asyncio
 async def test_get_current_user_valid_token(monkeypatch):
     # Arrange
     monkeypatch.setattr("app.core.security.get_keycloak_public_keys", mock_get_keycloak_public_keys)
     monkeypatch.setattr("jwt.decode", mock_jwt_decode)
-    
+
     # Act
     user = await get_current_user(MagicMock(cookies={"access_token": MOCK_TOKEN_VALID}))
-    
+
     # Assert
     assert isinstance(user, AuthenticatedUser)
     assert user.user_id == "test_user_id"
     assert user.username == "test_user"
     assert user.email == "test@example.com"
 
+
 @pytest.mark.asyncio
 async def test_get_current_user_invalid_token(monkeypatch):
     # Arrange
     monkeypatch.setattr("app.core.security.get_keycloak_public_keys", mock_get_keycloak_public_keys)
     monkeypatch.setattr("jose.jwt.decode", mock_jwt_decode)
-    
+
     # Act & Assert
     with pytest.raises(HTTPException) as exc_info:
         await get_current_user(MagicMock(cookies={"access_token": MOCK_TOKEN_INVALID}))
     assert exc_info.value.status_code == 401
+
 
 @pytest.mark.asyncio
 async def test_get_current_user_expired_token(monkeypatch):
     # Arrange
     monkeypatch.setattr("app.core.security.get_keycloak_public_keys", mock_get_keycloak_public_keys)
     monkeypatch.setattr("jose.jwt.decode", mock_jwt_decode)
-    
+
     # Act & Assert
     with pytest.raises(HTTPException) as exc_info:
         await get_current_user(MagicMock(cookies={"access_token": MOCK_TOKEN_EXPIRED}))
     assert exc_info.value.status_code == 401
+
 
 @pytest.mark.asyncio
 async def test_get_current_user_wrong_issuer(monkeypatch):
     # Arrange
     monkeypatch.setattr("app.core.security.get_keycloak_public_keys", mock_get_keycloak_public_keys)
     monkeypatch.setattr("jose.jwt.decode", mock_jwt_decode)
-    
+
     # Act & Assert
     with pytest.raises(HTTPException) as exc_info:
         await get_current_user(MagicMock(cookies={"access_token": MOCK_TOKEN_WRONG_ISSUER}))
     assert exc_info.value.status_code == 401
+
 
 @pytest.mark.asyncio
 async def test_get_current_user_wrong_audience(monkeypatch):
     # Arrange
     monkeypatch.setattr("app.core.security.get_keycloak_public_keys", mock_get_keycloak_public_keys)
     monkeypatch.setattr("jose.jwt.decode", mock_jwt_decode)
-    
+
     # Act & Assert
     with pytest.raises(HTTPException) as exc_info:
         await get_current_user(MagicMock(cookies={"access_token": MOCK_TOKEN_WRONG_AUDIENCE}))
     assert exc_info.value.status_code == 401
+
 
 @pytest.mark.asyncio
 async def test_get_current_user_no_token(monkeypatch):
@@ -193,11 +202,11 @@ async def test_get_current_user_no_token(monkeypatch):
     monkeypatch.setattr("jose.jwt.decode", mock_jwt_decode)
     from fastapi.responses import RedirectResponse
     from starlette.datastructures import URL
-    
+
     # Prepare mock request
     mock_request = MagicMock()
     mock_request.cookies = {}
-    mock_request.url = URL("http://testserver/some/path") # Use Starlette URL for .path attribute
+    mock_request.url = URL("http://testserver/some/path")  # Use Starlette URL for .path attribute
 
     # Act
     response = await get_current_user(mock_request)
@@ -206,6 +215,7 @@ async def test_get_current_user_no_token(monkeypatch):
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 307
     assert "/login?redirect=http://testserver/some/path" in response.headers["location"]
+
 
 @pytest.mark.asyncio
 async def test_get_current_active_user_disabled(monkeypatch):
@@ -216,12 +226,13 @@ async def test_get_current_active_user_disabled(monkeypatch):
         email="test@example.com",
         disabled=True
     )
-    
+
     # Act & Assert
     with pytest.raises(HTTPException) as exc_info:
         await get_current_active_user(disabled_user)
     assert exc_info.value.status_code == 400
     assert "Inactive user" in str(exc_info.value.detail)
+
 
 @pytest.mark.asyncio
 async def test_get_current_active_user_active(monkeypatch):
@@ -232,12 +243,13 @@ async def test_get_current_active_user_active(monkeypatch):
         email="test@example.com",
         disabled=False
     )
-    
+
     # Act
     result = await get_current_active_user(active_user)
-    
+
     # Assert
     assert result == active_user
+
 
 @pytest.mark.asyncio
 async def test_get_current_active_user_redirect_response():
@@ -251,21 +263,24 @@ async def test_get_current_active_user_redirect_response():
     # Assert
     assert result == redirect_response
 
+
 # Test protected routes for authentication
 def test_protected_route_without_auth():
     # Act
-    response = client.get("/my-workflows", follow_redirects=False) # Added follow_redirects=False
-    
+    response = client.get("/my-workflows", follow_redirects=False)  # Added follow_redirects=False
+
     # Assert
-    assert response.status_code == 307 # Check for redirect
-    assert "/login" in response.headers.get("location", "") # Check if redirected to login
+    assert response.status_code == 307  # Check for redirect
+    assert "/login" in response.headers.get("location", "")  # Check if redirected to login
+
 
 def test_protected_route_api_without_auth():
     # Act
     response = client.get("/api/my-workflows")
-    
+
     # Assert
-    assert response.status_code == 401 # API should return 401, not redirect
+    assert response.status_code == 401  # API should return 401, not redirect
+
 
 # Mocking Keycloak login and callback
 @pytest.mark.asyncio
@@ -273,14 +288,15 @@ async def test_login_redirect(monkeypatch):
     # Arrange
     mock_response = MagicMock()
     monkeypatch.setattr("requests.post", mock_response)
-    
+
     # Act
     response = client.get("/login", follow_redirects=False)
-    
+
     # Assert
     assert response.status_code == 307  # Redirect status code
     assert "realms" in response.headers.get('location', '')
     assert "openid-connect/auth" in response.headers.get('location', '')
+
 
 @pytest.mark.asyncio
 @pytest.mark.skip("Skipping protected route tests as they require human eyes")
@@ -293,13 +309,14 @@ async def test_callback_with_valid_code(monkeypatch):
         "expires_in": 3600
     }
     monkeypatch.setattr("requests.post", mock_response)
-    
+
     # Act
     response = client.get("/callback", params={"code": "valid_code", "state": "/"}, follow_redirects=False)
-    
+
     # Assert
     assert response.status_code == 303  # Redirect after successful token exchange
     assert "access_token" in response.cookies
+
 
 @pytest.mark.asyncio
 async def test_callback_with_invalid_code(monkeypatch):
@@ -308,18 +325,19 @@ async def test_callback_with_invalid_code(monkeypatch):
     mock_response.status_code = 400
     mock_response.text = "Invalid code"
     monkeypatch.setattr("requests.post", mock_response)
-    
+
     # Act
     response = client.get("/callback?code=invalid_code")
-    
+
     # Assert
     assert response.status_code == 400
+
 
 @pytest.mark.asyncio
 async def test_logout(monkeypatch):
     # Act
     response = client.get("/logout", follow_redirects=False)
-    
+
     # Assert
     assert response.status_code == 303  # Redirect to Keycloak logout
     assert "access_token" not in response.cookies or response.cookies.get("access_token", "") == ""

--- a/app/tests/test_services.py
+++ b/app/tests/test_services.py
@@ -1,14 +1,15 @@
-import pytest
-import sys
 import os
+import sys
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 # Add the project root to sys.path to ensure 'app' module can be found
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.db_models import Base
-from app.repository import PostgreSQLWorkflowRepository, DefinitionNotFoundError, DefinitionInUseError
+from app.repository import DefinitionNotFoundError, DefinitionInUseError
 from app.services import WorkflowService
 from app.models import WorkflowDefinition, WorkflowInstance, TaskInstance
 from app.db_models.enums import WorkflowStatus, TaskStatus
@@ -18,6 +19,7 @@ SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+
 @pytest.fixture
 def db_session():
     Base.metadata.create_all(bind=engine)
@@ -26,6 +28,7 @@ def db_session():
     session.close()
     Base.metadata.drop_all(bind=engine)
 
+
 @pytest.fixture
 def mock_repositories():
     definition_repo = MagicMock()
@@ -33,10 +36,12 @@ def mock_repositories():
     task_repo = MagicMock()
     return definition_repo, instance_repo, task_repo
 
+
 @pytest.fixture
 def workflow_service(mock_repositories):
     definition_repo, instance_repo, task_repo = mock_repositories
     return WorkflowService(definition_repo, instance_repo, task_repo)
+
 
 @pytest.mark.asyncio
 async def test_create_workflow_instance_success(workflow_service, mock_repositories):
@@ -76,6 +81,7 @@ async def test_create_workflow_instance_success(workflow_service, mock_repositor
     assert task_calls[1][0][0].name == "Task 2"
     assert task_calls[1][0][0].order == 1
 
+
 @pytest.mark.asyncio
 async def test_create_workflow_instance_definition_not_found(workflow_service, mock_repositories):
     # Arrange
@@ -87,6 +93,7 @@ async def test_create_workflow_instance_definition_not_found(workflow_service, m
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_complete_task_success(workflow_service, mock_repositories):
@@ -135,6 +142,7 @@ async def test_complete_task_success(workflow_service, mock_repositories):
     assert result is not None
     assert result.status == TaskStatus.completed
     assert instance_repo.update_workflow_instance.call_count == 0  # Not all tasks completed yet
+
 
 @pytest.mark.asyncio
 async def test_complete_task_all_tasks_completed(workflow_service, mock_repositories):
@@ -186,6 +194,7 @@ async def test_complete_task_all_tasks_completed(workflow_service, mock_reposito
     updated_instance = instance_repo.update_workflow_instance.call_args[0][1]
     assert updated_instance.status == WorkflowStatus.completed
 
+
 @pytest.mark.asyncio
 async def test_complete_task_already_completed(workflow_service, mock_repositories):
     # Arrange
@@ -204,6 +213,7 @@ async def test_complete_task_already_completed(workflow_service, mock_repositori
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_complete_task_unauthorized_user(workflow_service, mock_repositories):
@@ -232,6 +242,7 @@ async def test_complete_task_unauthorized_user(workflow_service, mock_repositori
     # Assert
     assert result is None
 
+
 @pytest.mark.asyncio
 async def test_create_new_definition_success(workflow_service, mock_repositories):
     # Arrange
@@ -256,6 +267,7 @@ async def test_create_new_definition_success(workflow_service, mock_repositories
     assert result.name == "Test Workflow"
     assert result.task_names == ["Task 1", "Task 2"]
 
+
 @pytest.mark.asyncio
 async def test_create_new_definition_empty_name(workflow_service, mock_repositories):
     # Arrange
@@ -269,6 +281,7 @@ async def test_create_new_definition_empty_name(workflow_service, mock_repositor
             task_names=["Task 1"]
         )
 
+
 @pytest.mark.asyncio
 async def test_create_new_definition_empty_task_list(workflow_service, mock_repositories):
     # Arrange
@@ -281,6 +294,7 @@ async def test_create_new_definition_empty_task_list(workflow_service, mock_repo
             description="A test workflow",
             task_names=[]
         )
+
 
 @pytest.mark.asyncio
 async def test_update_definition_success(workflow_service, mock_repositories):
@@ -307,6 +321,7 @@ async def test_update_definition_success(workflow_service, mock_repositories):
     assert result.name == "Updated Workflow"
     assert result.task_names == ["Updated Task 1"]
 
+
 @pytest.mark.asyncio
 async def test_update_definition_empty_name(workflow_service, mock_repositories):
     # Arrange
@@ -320,6 +335,7 @@ async def test_update_definition_empty_name(workflow_service, mock_repositories)
             description="Updated description",
             task_names=["Updated Task 1"]
         )
+
 
 @pytest.mark.asyncio
 async def test_update_definition_empty_task_list(workflow_service, mock_repositories):
@@ -335,6 +351,7 @@ async def test_update_definition_empty_task_list(workflow_service, mock_reposito
             task_names=[]
         )
 
+
 @pytest.mark.asyncio
 async def test_delete_definition_success(workflow_service, mock_repositories):
     # Arrange
@@ -347,6 +364,7 @@ async def test_delete_definition_success(workflow_service, mock_repositories):
     # Assert
     definition_repo.delete_workflow_definition.assert_called_once_with("test_def_1")
 
+
 @pytest.mark.asyncio
 async def test_delete_definition_not_found(workflow_service, mock_repositories):
     # Arrange
@@ -357,6 +375,7 @@ async def test_delete_definition_not_found(workflow_service, mock_repositories):
     with pytest.raises(ValueError, match="Definition not found"):
         await workflow_service.delete_definition("test_def_1")
 
+
 @pytest.mark.asyncio
 async def test_delete_definition_in_use(workflow_service, mock_repositories):
     # Arrange
@@ -366,6 +385,7 @@ async def test_delete_definition_in_use(workflow_service, mock_repositories):
     # Act & Assert
     with pytest.raises(ValueError, match="Definition in use"):
         await workflow_service.delete_definition("test_def_1")
+
 
 @pytest.mark.asyncio
 async def test_get_workflow_instance_with_tasks_success(workflow_service, mock_repositories):
@@ -398,6 +418,7 @@ async def test_get_workflow_instance_with_tasks_success(workflow_service, mock_r
     assert result["instance"] == instance
     assert result["tasks"] == tasks
 
+
 @pytest.mark.asyncio
 async def test_get_workflow_instance_with_tasks_unauthorized(workflow_service, mock_repositories):
     # Arrange
@@ -416,6 +437,7 @@ async def test_get_workflow_instance_with_tasks_unauthorized(workflow_service, m
 
     # Assert
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_list_instances_for_user(workflow_service, mock_repositories):
@@ -457,6 +479,7 @@ async def test_list_instances_for_user(workflow_service, mock_repositories):
 # Tests for list_instances_for_user with filters
 from datetime import date as DateObject
 
+
 @pytest.mark.asyncio
 async def test_list_instances_for_user_passthrough_no_filters(workflow_service, mock_repositories):
     _, instance_repo, _ = mock_repositories
@@ -472,6 +495,7 @@ async def test_list_instances_for_user_passthrough_no_filters(workflow_service, 
         status=None
     )
     assert result == expected_result
+
 
 @pytest.mark.asyncio
 async def test_list_instances_for_user_passthrough_with_date(workflow_service, mock_repositories):
@@ -490,6 +514,7 @@ async def test_list_instances_for_user_passthrough_with_date(workflow_service, m
     )
     assert result == expected_result
 
+
 @pytest.mark.asyncio
 async def test_list_instances_for_user_passthrough_with_status(workflow_service, mock_repositories):
     _, instance_repo, _ = mock_repositories
@@ -506,6 +531,7 @@ async def test_list_instances_for_user_passthrough_with_status(workflow_service,
         status=test_status
     )
     assert result == expected_result
+
 
 @pytest.mark.asyncio
 async def test_list_instances_for_user_passthrough_with_all_filters(workflow_service, mock_repositories):
@@ -535,6 +561,7 @@ OTHER_USER_ID = "other_user_456"
 WF_INSTANCE_ID = "wf_inst_abc"
 TASK_ID_1 = "task_def_123"
 
+
 @pytest.mark.asyncio
 async def test_undo_complete_task_success_workflow_becomes_active(workflow_service, mock_repositories):
     # Arrange
@@ -552,19 +579,19 @@ async def test_undo_complete_task_success_workflow_becomes_active(workflow_servi
         workflow_definition_id="def_id_1",
         name="Test Workflow",
         user_id=USER_ID,
-        status=WorkflowStatus.completed # Workflow was completed
+        status=WorkflowStatus.completed  # Workflow was completed
     )
 
     task_repo.get_task_instance_by_id = AsyncMock(return_value=completed_task)
     instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=workflow_instance)
-    
+
     # Mock the update methods to return the object passed to them, modified
     async def update_task_side_effect(task_id, task_data):
         # In a real scenario, this would update and return the updated object.
         # For the mock, we'll just reflect the change.
         completed_task.status = task_data.status
         return completed_task
-    
+
     async def update_workflow_side_effect(wf_id, wf_data):
         workflow_instance.status = wf_data.status
         return workflow_instance
@@ -581,9 +608,10 @@ async def test_undo_complete_task_success_workflow_becomes_active(workflow_servi
     assert result.status == TaskStatus.pending
     task_repo.update_task_instance.assert_called_once()
     assert task_repo.update_task_instance.call_args[0][1].status == TaskStatus.pending
-    
+
     instance_repo.update_workflow_instance.assert_called_once()
     assert instance_repo.update_workflow_instance.call_args[0][1].status == WorkflowStatus.active
+
 
 @pytest.mark.asyncio
 async def test_undo_complete_task_task_not_found(workflow_service, mock_repositories):
@@ -597,7 +625,8 @@ async def test_undo_complete_task_task_not_found(workflow_service, mock_reposito
     # Assert
     assert result is None
     task_repo.update_task_instance.assert_not_called()
-    mock_repositories[1].update_workflow_instance.assert_not_called() # instance_repo
+    mock_repositories[1].update_workflow_instance.assert_not_called()  # instance_repo
+
 
 @pytest.mark.asyncio
 async def test_undo_complete_task_task_not_completed(workflow_service, mock_repositories):
@@ -608,7 +637,7 @@ async def test_undo_complete_task_task_not_completed(workflow_service, mock_repo
         workflow_instance_id=WF_INSTANCE_ID,
         name="Test Task 1",
         order=0,
-        status=TaskStatus.pending # Task is not completed
+        status=TaskStatus.pending  # Task is not completed
     )
     task_repo.get_task_instance_by_id = AsyncMock(return_value=pending_task)
 
@@ -618,7 +647,8 @@ async def test_undo_complete_task_task_not_completed(workflow_service, mock_repo
     # Assert
     assert result is None
     task_repo.update_task_instance.assert_not_called()
-    mock_repositories[1].update_workflow_instance.assert_not_called() # instance_repo
+    mock_repositories[1].update_workflow_instance.assert_not_called()  # instance_repo
+
 
 @pytest.mark.asyncio
 async def test_undo_complete_task_workflow_not_found(workflow_service, mock_repositories):
@@ -626,13 +656,13 @@ async def test_undo_complete_task_workflow_not_found(workflow_service, mock_repo
     _, instance_repo, task_repo = mock_repositories
     completed_task = TaskInstance(
         id=TASK_ID_1,
-        workflow_instance_id="non_existent_wf_id", # Points to a non-existent workflow
+        workflow_instance_id="non_existent_wf_id",  # Points to a non-existent workflow
         name="Test Task 1",
         order=0,
         status=TaskStatus.completed
     )
     task_repo.get_task_instance_by_id = AsyncMock(return_value=completed_task)
-    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None) # Workflow not found
+    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None)  # Workflow not found
 
     # Act
     result = await workflow_service.undo_complete_task(TASK_ID_1, USER_ID)
@@ -641,6 +671,7 @@ async def test_undo_complete_task_workflow_not_found(workflow_service, mock_repo
     assert result is None
     task_repo.update_task_instance.assert_not_called()
     instance_repo.update_workflow_instance.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_undo_complete_task_user_unauthorized(workflow_service, mock_repositories):
@@ -657,19 +688,20 @@ async def test_undo_complete_task_user_unauthorized(workflow_service, mock_repos
         id=WF_INSTANCE_ID,
         workflow_definition_id="def_id_1",
         name="Test Workflow",
-        user_id=OTHER_USER_ID, # Belongs to a different user
+        user_id=OTHER_USER_ID,  # Belongs to a different user
         status=WorkflowStatus.completed
     )
     task_repo.get_task_instance_by_id = AsyncMock(return_value=completed_task)
     instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=workflow_instance)
 
     # Act
-    result = await workflow_service.undo_complete_task(TASK_ID_1, USER_ID) # Current user is USER_ID
+    result = await workflow_service.undo_complete_task(TASK_ID_1, USER_ID)  # Current user is USER_ID
 
     # Assert
     assert result is None
     task_repo.update_task_instance.assert_not_called()
     instance_repo.update_workflow_instance.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_undo_complete_task_workflow_remains_active(workflow_service, mock_repositories):
@@ -689,12 +721,12 @@ async def test_undo_complete_task_workflow_remains_active(workflow_service, mock
         workflow_definition_id="def_id_1",
         name="Test Workflow",
         user_id=USER_ID,
-        status=WorkflowStatus.active # Workflow is already active
+        status=WorkflowStatus.active  # Workflow is already active
     )
 
     task_repo.get_task_instance_by_id = AsyncMock(return_value=completed_task_to_undo)
     instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=workflow_instance)
-    
+
     async def update_task_side_effect(task_id, task_data):
         completed_task_to_undo.status = task_data.status
         return completed_task_to_undo
@@ -708,10 +740,10 @@ async def test_undo_complete_task_workflow_remains_active(workflow_service, mock
     assert result is not None
     assert result.id == TASK_ID_1
     assert result.status == TaskStatus.pending
-    
+
     task_repo.update_task_instance.assert_called_once()
     assert task_repo.update_task_instance.call_args[0][1].status == TaskStatus.pending
-    
+
     # Crucially, update_workflow_instance should NOT be called if workflow was already active
     instance_repo.update_workflow_instance.assert_not_called()
 
@@ -720,6 +752,7 @@ async def test_undo_complete_task_workflow_remains_active(workflow_service, mock
 ARCHIVE_USER_ID = "archive_user"
 ARCHIVE_INSTANCE_ID = "archive_instance_id"
 OTHER_USER_ID_ARCHIVE = "other_archive_user"
+
 
 @pytest.mark.asyncio
 async def test_archive_workflow_instance_success(workflow_service, mock_repositories):
@@ -733,10 +766,11 @@ async def test_archive_workflow_instance_success(workflow_service, mock_reposito
         workflow_definition_id="def_archive"
     )
     instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=active_instance)
-    
+
     async def mock_update_instance(instance_id, instance_data):
         # Simulate the update operation by returning the instance_data passed
         return instance_data
+
     instance_repo.update_workflow_instance = AsyncMock(side_effect=mock_update_instance)
 
     # Act
@@ -752,13 +786,14 @@ async def test_archive_workflow_instance_success(workflow_service, mock_reposito
     assert updated_data.status == WorkflowStatus.archived
     assert updated_data.id == ARCHIVE_INSTANCE_ID
 
+
 @pytest.mark.asyncio
 async def test_archive_workflow_instance_not_owned_by_user(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
     instance_other_user = WorkflowInstance(
         id=ARCHIVE_INSTANCE_ID,
-        user_id=OTHER_USER_ID_ARCHIVE, # Belongs to a different user
+        user_id=OTHER_USER_ID_ARCHIVE,  # Belongs to a different user
         status=WorkflowStatus.active,
         name="Test Archive Other User",
         workflow_definition_id="def_archive"
@@ -773,6 +808,7 @@ async def test_archive_workflow_instance_not_owned_by_user(workflow_service, moc
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(ARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_archive_workflow_instance_already_completed(workflow_service, mock_repositories):
     # Arrange
@@ -780,7 +816,7 @@ async def test_archive_workflow_instance_already_completed(workflow_service, moc
     completed_instance = WorkflowInstance(
         id=ARCHIVE_INSTANCE_ID,
         user_id=ARCHIVE_USER_ID,
-        status=WorkflowStatus.completed, # Already completed
+        status=WorkflowStatus.completed,  # Already completed
         name="Test Archive Completed",
         workflow_definition_id="def_archive"
     )
@@ -794,11 +830,12 @@ async def test_archive_workflow_instance_already_completed(workflow_service, moc
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(ARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_archive_workflow_instance_non_existent(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
-    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None) # Instance does not exist
+    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None)  # Instance does not exist
 
     # Act
     result = await workflow_service.archive_workflow_instance("non_existent_id", ARCHIVE_USER_ID)
@@ -808,6 +845,7 @@ async def test_archive_workflow_instance_non_existent(workflow_service, mock_rep
     instance_repo.get_workflow_instance_by_id.assert_called_once_with("non_existent_id")
     instance_repo.update_workflow_instance.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_archive_workflow_instance_already_archived(workflow_service, mock_repositories):
     # Arrange
@@ -815,7 +853,7 @@ async def test_archive_workflow_instance_already_archived(workflow_service, mock
     archived_instance = WorkflowInstance(
         id=ARCHIVE_INSTANCE_ID,
         user_id=ARCHIVE_USER_ID,
-        status=WorkflowStatus.archived, # Already archived
+        status=WorkflowStatus.archived,  # Already archived
         name="Test Archive Already Archived",
         workflow_definition_id="def_archive"
     )
@@ -827,29 +865,30 @@ async def test_archive_workflow_instance_already_archived(workflow_service, mock
     # Assert
     assert result is not None
     assert result.status == WorkflowStatus.archived
-    assert result.id == ARCHIVE_INSTANCE_ID # Ensure it's the same instance
+    assert result.id == ARCHIVE_INSTANCE_ID  # Ensure it's the same instance
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(ARCHIVE_INSTANCE_ID)
-    instance_repo.update_workflow_instance.assert_not_called() # Should not call update if already archived
+    instance_repo.update_workflow_instance.assert_not_called()  # Should not call update if already archived
 
 
-# Tests for list_instances_for_user focusing on ARCHIVED status
+# Tests for list_instances_for_user focusing on archived status
 LIST_USER_ID = "list_test_user"
+
 
 @pytest.mark.asyncio
 async def test_list_instances_for_user_filters_archived_status(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
-    
+
     archived_instance_mock = WorkflowInstance(
-        id="inst_archived_1", user_id=LIST_USER_ID, status=WorkflowStatus.archived, 
+        id="inst_archived_1", user_id=LIST_USER_ID, status=WorkflowStatus.archived,
         name="Archived Wf", workflow_definition_id="def_1"
     )
-    # Simulate that the repository method, when called with status=ARCHIVED, returns only archived instances.
+    # Simulate that the repository method, when called with status=archived, returns only archived instances.
     instance_repo.list_workflow_instances_by_user = AsyncMock(return_value=[archived_instance_mock])
 
-    # Act: Call the service method requesting ARCHIVED instances
+    # Act: Call the service method requesting archived instances
     result = await workflow_service.list_instances_for_user(
-        user_id=LIST_USER_ID, 
+        user_id=LIST_USER_ID,
         status=WorkflowStatus.archived
     )
 
@@ -857,19 +896,20 @@ async def test_list_instances_for_user_filters_archived_status(workflow_service,
     assert len(result) == 1
     assert result[0].id == "inst_archived_1"
     assert result[0].status == WorkflowStatus.archived
-    
+
     # Verify the repository was called correctly by the service
     instance_repo.list_workflow_instances_by_user.assert_called_once_with(
         user_id=LIST_USER_ID,
-        created_at_date=None, # Default if not provided
+        created_at_date=None,  # Default if not provided
         status=WorkflowStatus.archived
     )
+
 
 @pytest.mark.asyncio
 async def test_list_instances_for_user_active_status_excludes_archived(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
-    
+
     active_instance_mock = WorkflowInstance(
         id="inst_active_1", user_id=LIST_USER_ID, status=WorkflowStatus.active,
         name="Active Wf", workflow_definition_id="def_2"
@@ -879,7 +919,7 @@ async def test_list_instances_for_user_active_status_excludes_archived(workflow_
 
     # Act: Call the service method requesting ACTIVE instances
     result = await workflow_service.list_instances_for_user(
-        user_id=LIST_USER_ID, 
+        user_id=LIST_USER_ID,
         status=WorkflowStatus.active
     )
 
@@ -887,18 +927,19 @@ async def test_list_instances_for_user_active_status_excludes_archived(workflow_
     assert len(result) == 1
     assert result[0].id == "inst_active_1"
     assert result[0].status == WorkflowStatus.active
-    
+
     instance_repo.list_workflow_instances_by_user.assert_called_once_with(
         user_id=LIST_USER_ID,
         created_at_date=None,
         status=WorkflowStatus.active
     )
 
+
 @pytest.mark.asyncio
 async def test_list_instances_for_user_no_status_filter_passes_none_to_repo(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
-    
+
     active_instance_mock = WorkflowInstance(
         id="inst_active_2", user_id=LIST_USER_ID, status=WorkflowStatus.active,
         name="Active Wf 2", workflow_definition_id="def_3"
@@ -918,18 +959,20 @@ async def test_list_instances_for_user_no_status_filter_passes_none_to_repo(work
     assert len(result) == 2
     assert any(inst.status == WorkflowStatus.archived for inst in result)
     assert any(inst.status == WorkflowStatus.active for inst in result)
-    
+
     # Crucially, verify that status=None was passed to the repository
     instance_repo.list_workflow_instances_by_user.assert_called_once_with(
         user_id=LIST_USER_ID,
         created_at_date=None,
-        status=None # This is the key assertion for this test
+        status=None  # This is the key assertion for this test
     )
+
 
 # Constants for unarchive tests (can reuse some from archive or define new ones for clarity)
 UNARCHIVE_USER_ID = "unarchive_user"
 UNARCHIVE_INSTANCE_ID = "unarchive_instance_id"
 OTHER_USER_ID_UNARCHIVE = "other_unarchive_user"
+
 
 @pytest.mark.asyncio
 async def test_unarchive_workflow_instance_success(workflow_service, mock_repositories):
@@ -938,14 +981,15 @@ async def test_unarchive_workflow_instance_success(workflow_service, mock_reposi
     archived_instance = WorkflowInstance(
         id=UNARCHIVE_INSTANCE_ID,
         user_id=UNARCHIVE_USER_ID,
-        status=WorkflowStatus.ARCHIVED, # Instance is archived
+        status=WorkflowStatus.archived,  # Instance is archived
         name="Test Unarchive Success",
         workflow_definition_id="def_unarchive_succ"
     )
     instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=archived_instance)
-    
+
     async def mock_update_instance(instance_id, instance_data):
-        return instance_data # Simulate update by returning the passed data
+        return instance_data  # Simulate update by returning the passed data
+
     instance_repo.update_workflow_instance = AsyncMock(side_effect=mock_update_instance)
 
     # Act
@@ -953,12 +997,13 @@ async def test_unarchive_workflow_instance_success(workflow_service, mock_reposi
 
     # Assert
     assert result is not None
-    assert result.status == WorkflowStatus.active # Status should now be active
+    assert result.status == WorkflowStatus.active  # Status should now be active
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(UNARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_called_once()
     updated_data = instance_repo.update_workflow_instance.call_args[0][1]
     assert updated_data.status == WorkflowStatus.active
     assert updated_data.id == UNARCHIVE_INSTANCE_ID
+
 
 @pytest.mark.asyncio
 async def test_unarchive_workflow_instance_not_archived_active(workflow_service, mock_repositories):
@@ -967,7 +1012,7 @@ async def test_unarchive_workflow_instance_not_archived_active(workflow_service,
     active_instance = WorkflowInstance(
         id=UNARCHIVE_INSTANCE_ID,
         user_id=UNARCHIVE_USER_ID,
-        status=WorkflowStatus.active, # Instance is active, not archived
+        status=WorkflowStatus.active,  # Instance is active, not archived
         name="Test Unarchive Not Archived - Active",
         workflow_definition_id="def_unarchive_active"
     )
@@ -977,9 +1022,10 @@ async def test_unarchive_workflow_instance_not_archived_active(workflow_service,
     result = await workflow_service.unarchive_workflow_instance(UNARCHIVE_INSTANCE_ID, UNARCHIVE_USER_ID)
 
     # Assert
-    assert result is None # Should not unarchive if not currently archived
+    assert result is None  # Should not unarchive if not currently archived
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(UNARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_unarchive_workflow_instance_not_archived_completed(workflow_service, mock_repositories):
@@ -988,7 +1034,7 @@ async def test_unarchive_workflow_instance_not_archived_completed(workflow_servi
     completed_instance = WorkflowInstance(
         id=UNARCHIVE_INSTANCE_ID,
         user_id=UNARCHIVE_USER_ID,
-        status=WorkflowStatus.completed, # Instance is completed, not archived
+        status=WorkflowStatus.completed,  # Instance is completed, not archived
         name="Test Unarchive Not Archived - Completed",
         workflow_definition_id="def_unarchive_completed"
     )
@@ -998,9 +1044,10 @@ async def test_unarchive_workflow_instance_not_archived_completed(workflow_servi
     result = await workflow_service.unarchive_workflow_instance(UNARCHIVE_INSTANCE_ID, UNARCHIVE_USER_ID)
 
     # Assert
-    assert result is None # Should not unarchive if not currently archived
+    assert result is None  # Should not unarchive if not currently archived
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(UNARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_unarchive_workflow_instance_not_owned_by_user(workflow_service, mock_repositories):
@@ -1008,8 +1055,8 @@ async def test_unarchive_workflow_instance_not_owned_by_user(workflow_service, m
     _, instance_repo, _ = mock_repositories
     instance_other_user = WorkflowInstance(
         id=UNARCHIVE_INSTANCE_ID,
-        user_id=OTHER_USER_ID_UNARCHIVE, # Belongs to a different user
-        status=WorkflowStatus.ARCHIVED,
+        user_id=OTHER_USER_ID_UNARCHIVE,  # Belongs to a different user
+        status=WorkflowStatus.archived,
         name="Test Unarchive Other User",
         workflow_definition_id="def_unarchive_other"
     )
@@ -1023,11 +1070,12 @@ async def test_unarchive_workflow_instance_not_owned_by_user(workflow_service, m
     instance_repo.get_workflow_instance_by_id.assert_called_once_with(UNARCHIVE_INSTANCE_ID)
     instance_repo.update_workflow_instance.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_unarchive_workflow_instance_non_existent(workflow_service, mock_repositories):
     # Arrange
     _, instance_repo, _ = mock_repositories
-    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None) # Instance does not exist
+    instance_repo.get_workflow_instance_by_id = AsyncMock(return_value=None)  # Instance does not exist
 
     # Act
     result = await workflow_service.unarchive_workflow_instance("non_existent_unarchive_id", UNARCHIVE_USER_ID)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,8 +1,11 @@
 from typing import List
+
 from fastapi import Request, Depends
 from fastapi.responses import HTMLResponse
+
 from app.core.html_renderer import HtmlRendererInterface
 from app.dependencies import get_html_renderer
+
 
 async def create_message_page(
         request: Request,
@@ -19,7 +22,7 @@ async def create_message_page(
         heading_style = "color: #ef4444;"
     elif "warn" in title.lower():
         heading_style = "color: #f6ad55;"
-    
+
     response = await renderer.render(
         "message.html",
         request,


### PR DESCRIPTION
This commit introduces the ability to unarchive workflow instances, changing their status from 'ARCHIVED' back to 'ACTIVE'.

Changes include:
- Added `unarchive_workflow_instance` method to `WorkflowService` to handle the logic of unarchiving.
- Added a new POST API endpoint `/workflow-instances/{instance_id}/unarchive` to trigger the unarchiving process.
- Updated `workflow_instance.html` to include an 'Unarchive Workflow' button, which is visible only for instances with 'ARCHIVED' status.
- Added unit tests for the `unarchive_workflow_instance` service method.
- Added integration tests for the `/workflow-instances/{instance_id}/unarchive` API endpoint.