### PR TITLE
feat: Implement shareable links for workflow instances

### DIFF
--- a/alembic/versions/88279b51651c_add_share_token_to_workflow_instances.py
+++ b/alembic/versions/88279b51651c_add_share_token_to_workflow_instances.py
@@ -1,0 +1,26 @@
+"""add_share_token_to_workflow_instances
+
+Revision ID: 88279b51651c
+Revises: add_archived_status_enum
+Create Date: 2025-06-02 22:47:17.392002
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '88279b51651c'
+down_revision = 'add_archived_status_enum' # This was confirmed to be correct
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('workflow_instances', sa.Column('share_token', sa.String(), nullable=True))
+    op.create_index(op.f('ix_workflow_instances_share_token'), 'workflow_instances', ['share_token'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_workflow_instances_share_token'), table_name='workflow_instances')
+    op.drop_column('workflow_instances', 'share_token')

--- a/app/db_models/workflow.py
+++ b/app/db_models/workflow.py
@@ -28,6 +28,7 @@ class WorkflowInstance(Base):
     user_id = Column(String, index=True, nullable=False)
     status = Column(SQLAlchemyEnum(WorkflowStatus), nullable=False, default=WorkflowStatus.active)
     created_at = Column(Date, nullable=False)
+    share_token = Column(String, unique=True, index=True, nullable=True)
 
     definition = relationship("WorkflowDefinition", back_populates="instances")
     tasks = relationship("TaskInstance", back_populates="workflow_instance", order_by="TaskInstance.order")

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from app.routers import root, workflow_definitions, workflow_instances, tasks, auth, user_workflows, api
+from app.routers import root, workflow_definitions, workflow_instances, tasks, auth, user_workflows, api, share
 
 app = FastAPI(
     redirect_slashes=False,
@@ -23,3 +23,4 @@ app.include_router(tasks.router)
 app.include_router(auth.router)
 app.include_router(user_workflows.router)
 app.include_router(api.router)
+app.include_router(share.router)

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,7 @@ class WorkflowInstance(BaseModel):
     user_id: str
     status: WorkflowStatus = WorkflowStatus.active
     created_at: DateObject = Field(default_factory=DateObject.today)
+    share_token: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+
+from app.services import WorkflowService
+from app.dependencies import get_workflow_service, get_html_renderer
+from app.core.html_renderer import HtmlRendererInterface
+# Ensure app.utils.create_message_page is available or define a similar utility if needed
+from app.utils import create_message_page 
+
+router = APIRouter(prefix="/share", tags=["share"])
+
+@router.get("/workflow/{share_token}", response_class=HTMLResponse, name="view_shared_workflow_instance")
+async def view_shared_workflow_instance(
+    request: Request,
+    share_token: str,
+    service: WorkflowService = Depends(get_workflow_service),
+    renderer: HtmlRendererInterface = Depends(get_html_renderer)
+):
+    details = await service.get_workflow_instance_by_share_token(share_token)
+
+    if not details or not details.get("instance"):
+        # Use create_message_page or a simple HTTPException for error display
+        # For example, using create_message_page:
+        return await create_message_page(
+            request, 
+            "Not Found", 
+            "Error 404 - Not Found", 
+            "The shared workflow link is invalid or the workflow was not found.", 
+            [("← Home", "/")], # Provide a link to a safe page
+            status_code=404, 
+            renderer=renderer
+        )
+        # Alternatively, a simpler HTTPException:
+        # raise HTTPException(status_code=404, detail="Shared workflow not found or link is invalid.")
+
+    instance = details["instance"]
+    tasks = details["tasks"]
+    
+    # Assuming 'workflow_instance.html' is the correct template name
+    return await renderer.render(
+        "workflow_instance.html", # The existing template
+        request,
+        {"instance": instance, "tasks": tasks, "is_shared_view": True} # Pass an extra flag
+    )

--- a/app/templates/workflow_instance.html
+++ b/app/templates/workflow_instance.html
@@ -6,6 +6,11 @@
     <p><strong>ID:</strong> {{ instance.id }}</p>
     <p><strong>Status:</strong> {{ instance.status.upper() }}</p>
     <p><strong>Created At:</strong> {{ instance.created_at.isoformat() }}</p>
+    {% if is_shared_view %}
+        <p style="background-color: #e0f2fe; border-left: 5px solid #3b82f6; padding: 10px; margin-top: 10px;">
+            You are viewing this workflow via a shared link (read-only).
+        </p>
+    {% endif %}
     <h2>Tasks:</h2>
     {% if not tasks %}
     <p>No tasks available for this workflow.</p>
@@ -14,16 +19,18 @@
         {% for task in tasks %}
         <li class="task-item" style="margin-bottom:10px;">
             <p><strong>Task:</strong> {{ task.name }} - {{ task.status.upper() }}</p>
-            {% if task.status == "pending" %}
-            <form action="/task-instances/{{ task.id }}/complete" method="post"
-                  style="display:inline; margin-left:10px;">
-                <button type="submit" class="action-button submit">Mark Complete</button>
-            </form>
-            {% elif task.status == "completed" %}
-            <form action="/task-instances/{{ task.id }}/undo-complete" method="post"
-                  style="display:inline; margin-left:10px;">
-                <button type="submit" class="button is-info is-small">Undo Complete</button>
-            </form>
+            {% if not is_shared_view %}
+                {% if task.status == "pending" %}
+                <form action="/task-instances/{{ task.id }}/complete" method="post"
+                      style="display:inline; margin-left:10px;">
+                    <button type="submit" class="action-button submit">Mark Complete</button>
+                </form>
+                {% elif task.status == "completed" %}
+                <form action="/task-instances/{{ task.id }}/undo-complete" method="post"
+                      style="display:inline; margin-left:10px;">
+                    <button type="submit" class="button is-info is-small">Undo Complete</button>
+                </form>
+                {% endif %}
             {% endif %}
         </li>
         {% endfor %}
@@ -33,19 +40,45 @@
     <p style="color: green; font-weight: bold; font-size:1.2em; margin-top:15px;">🎉 Workflow Complete!</p>
     {% endif %}
 
-    {% if instance.status == "active" %}
-    <form action="/workflow-instances/{{ instance.id }}/archive" method="post" style="margin-top:15px;">
-        <button type="submit" class="action-button">Archive Workflow</button>
-    </form>
-    {% endif %}
+    {% if not is_shared_view %}
+    <div class="workflow-actions" style="margin-top:20px;">
+        <h3>Workflow Actions:</h3>
+        {% if instance.status == "active" %}
+        <form action="/workflow-instances/{{ instance.id }}/archive" method="post" style="display:inline-block; margin-right:10px;">
+            <button type="submit" class="action-button">Archive Workflow</button>
+        </form>
+        {% endif %}
 
-    {% if instance.status == "archived" %}
-    <form action="/workflow-instances/{{ instance.id }}/unarchive" method="post" style="margin-top:15px;">
-        <button type="submit" class="action-button">Unarchive Workflow</button>
-    </form>
+        {% if instance.status == "archived" %}
+        <form action="/workflow-instances/{{ instance.id }}/unarchive" method="post" style="display:inline-block; margin-right:10px;">
+            <button type="submit" class="action-button">Unarchive Workflow</button>
+        </form>
+        {% endif %}
+    </div>
+
+    <div class="share-section" style="margin-top:20px; padding:15px; border:1px solid #ccc; border-radius:5px; background-color:#f9f9f9;">
+        <h3>Share this Workflow</h3>
+        {% if instance.share_token %}
+            <p>Shareable Link (read-only):</p>
+            <input type="text" value="{{ request.url_for('view_shared_workflow_instance', share_token=instance.share_token) }}" readonly style="width: 90%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 5px;">
+            <p style="font-size:0.9em; color: #555;">Anyone with this link can view this workflow instance without logging in.</p>
+        {% else %}
+            <p>Generate a shareable link to allow others to view this workflow instance (read-only).</p>
+        {% endif %}
+        <form action="{{ request.url_for('generate_share_link_handler', instance_id=instance.id) }}" method="post" style="margin-top:10px;">
+            <button type="submit" class="action-button">
+                {% if instance.share_token %}Refresh/Re-enable Share Link{% else %}Generate Share Link{% endif %}
+            </button>
+        </form>
+    </div>
     {% endif %}
 </div>
-<a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Workflow
-    Definitions</a>
-<a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
+
+{% if not is_shared_view %}
+    <a href="/workflow-definitions" class="back-link" style="margin-top:20px; display:inline-block;">← Back to Workflow Definitions</a>
+    <a href="/" class="back-link" style="margin-top:20px; display:inline-block; margin-left:15px;">← Back to Home</a>
+{% else %}
+    <p style="margin-top:20px; font-style:italic;">You are viewing a shared workflow instance. No actions are available.</p>
+    <a href="/" class="back-link" style="margin-top:10px; display:inline-block;">← Back to Home</a>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This feature allows you to generate a unique, read-only URL for a specific workflow instance, which can be shared with others who do not need to authenticate to view the workflow's status and task details.

Key changes include:
- Added a `share_token` field to the `WorkflowInstance` model and database schema.
- Introduced service methods to generate and retrieve workflow instances via these tokens.
- Created a new public API endpoint `/share/workflow/{share_token}` to serve the read-only view.
- Added a new authenticated API endpoint for you to generate these shareable links for your workflow instances.
- Updated the workflow instance page UI to:
    - Allow owners to generate/refresh shareable links.
    - Display the shareable link if one exists.
    - Conditionally render a read-only view (hiding action buttons) when accessed via a share token.
- Added comprehensive unit and integration tests for the new functionality.