### PR TITLE
feat: Add button to filter workflow instances by definition

### DIFF
--- a/app/routers/user_workflows.py
+++ b/app/routers/user_workflows.py
@@ -18,6 +18,7 @@ async def list_user_workflows(
         request: Request,
         created_at: Optional[str] = Query(None, description="Filter by creation date (YYYY-MM-DD)"),
         status: Optional[str] = Query(None, description="Filter by workflow status (string value like 'active')"),
+        definition_id: Optional[str] = Query(None),
         service: WorkflowService = Depends(get_workflow_service),
         current_user: AuthenticatedUser = Depends(get_current_active_user),
         renderer: HtmlRendererInterface = Depends(get_html_renderer)
@@ -63,7 +64,8 @@ async def list_user_workflows(
     instances = await service.list_instances_for_user(
         user_id=current_user.user_id,
         created_at_date=created_at_for_service,  # Pass the determined date object
-        status=status_for_service  # Pass the refined status for service (can be None)
+        status=status_for_service,  # Pass the refined status for service (can be None)
+        definition_id=definition_id
     )
 
     # For the template, if 'created_at' (the string query param) was provided, use it.
@@ -76,6 +78,7 @@ async def list_user_workflows(
             "instances": instances,
             "selected_created_at": selected_created_at_str,
             "selected_status": selected_status_for_template,  # Use the newly determined value
-            "workflow_statuses": [s.value for s in WorkflowStatus]  # For dropdown
+            "workflow_statuses": [s.value for s in WorkflowStatus],  # For dropdown
+            "selected_definition_id": definition_id
         }
     )

--- a/app/services.py
+++ b/app/services.py
@@ -69,9 +69,9 @@ class WorkflowService:
         return updated_task
 
     async def list_instances_for_user(self, user_id: str, created_at_date: Optional[DateObject] = None,
-                                      status: Optional[WorkflowStatus] = None) -> List[WorkflowInstance]:
+                                      status: Optional[WorkflowStatus] = None, definition_id: Optional[str] = None) -> List[WorkflowInstance]:
         return await self.instance_repo.list_workflow_instances_by_user(user_id, created_at_date=created_at_date,
-                                                                        status=status)
+                                                                        status=status, definition_id=definition_id)
 
     async def create_new_definition(self, name: str, description: Optional[str],
                                     task_names: List[str]) -> WorkflowDefinition:

--- a/app/templates/my_workflows.html
+++ b/app/templates/my_workflows.html
@@ -3,6 +3,10 @@
 {% block content %}
 <h1>My Workflows</h1>
 
+{% if selected_definition_id %}
+<p>Showing instances filtered by Definition ID: <strong>{{ selected_definition_id }}</strong>. <a href="/my-workflows">Clear filter</a></p>
+{% endif %}
+
 <form method="GET" action="{{ request.url.path }}" class="filter-form">
     <div class="filter-group">
         <label for="created_at">Created Date:</label>

--- a/app/templates/workflow_definitions.html
+++ b/app/templates/workflow_definitions.html
@@ -21,6 +21,7 @@
               style="display:inline; margin-left: 10px;">
             <button type="submit" class="action-button cancel">Delete</button>
         </form>
+        <a href="/my-workflows?definition_id={{ defn.id }}" class="action-button" style="margin-left: 10px;">View Instances</a>
     </li>
     {% endfor %}
 </ul>

--- a/app/tests/test_api_endpoints.py
+++ b/app/tests/test_api_endpoints.py
@@ -533,7 +533,8 @@ async def test_my_workflows_no_query_parameters(mock_dependencies_for_my_workflo
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,  # from global mock_user via override_get_current_active_user
         created_at_date=date.today(),
-        status=WorkflowStatus.active
+        status=WorkflowStatus.active,
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -542,7 +543,8 @@ async def test_my_workflows_no_query_parameters(mock_dependencies_for_my_workflo
             "instances": [],  # Default return from mock_service.list_instances_for_user
             "selected_created_at": date.today().isoformat(),
             "selected_status": "active",
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1054,7 +1056,8 @@ async def test_my_workflows_with_created_at(mock_dependencies_for_my_workflows):
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=test_date_obj,
-        status=WorkflowStatus.active
+        status=WorkflowStatus.active,
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1063,7 +1066,8 @@ async def test_my_workflows_with_created_at(mock_dependencies_for_my_workflows):
             "instances": [],
             "selected_created_at": test_date_str,
             "selected_status": "active",
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1079,7 +1083,8 @@ async def test_my_workflows_with_status(mock_dependencies_for_my_workflows):
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=WorkflowStatus.completed
+        status=WorkflowStatus.completed,
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1088,7 +1093,8 @@ async def test_my_workflows_with_status(mock_dependencies_for_my_workflows):
             "instances": [],
             "selected_created_at": date.today().isoformat(),
             "selected_status": "completed",
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1104,7 +1110,8 @@ async def test_my_workflows_with_all_statuses(mock_dependencies_for_my_workflows
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=None  # Service receives None for "All Statuses"
+        status=None,  # Service receives None for "All Statuses"
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1113,7 +1120,8 @@ async def test_my_workflows_with_all_statuses(mock_dependencies_for_my_workflows
             "instances": [],
             "selected_created_at": date.today().isoformat(),
             "selected_status": "",  # Template receives empty string
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1132,7 +1140,8 @@ async def test_my_workflows_with_created_at_and_status(mock_dependencies_for_my_
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=test_date_obj,
-        status=WorkflowStatus.pending
+        status=WorkflowStatus.pending,
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1141,7 +1150,8 @@ async def test_my_workflows_with_created_at_and_status(mock_dependencies_for_my_
             "instances": [],
             "selected_created_at": test_date_str,
             "selected_status": "pending",
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1158,7 +1168,8 @@ async def test_my_workflows_invalid_created_at(mock_dependencies_for_my_workflow
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=WorkflowStatus.active
+        status=WorkflowStatus.active,
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1167,7 +1178,8 @@ async def test_my_workflows_invalid_created_at(mock_dependencies_for_my_workflow
             "instances": [],
             "selected_created_at": date.today().isoformat(),
             "selected_status": "active",
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
         }
     )
 
@@ -1184,7 +1196,8 @@ async def test_my_workflows_invalid_status(mock_dependencies_for_my_workflows):
     mock_service.list_instances_for_user.assert_called_once_with(
         user_id=mock_user.user_id,
         created_at_date=date.today(),
-        status=WorkflowStatus.active  # Default for invalid status string
+        status=WorkflowStatus.active,  # Default for invalid status string
+        definition_id=None  # Added
     )
     mock_renderer.render.assert_called_once_with(
         "my_workflows.html",
@@ -1193,6 +1206,68 @@ async def test_my_workflows_invalid_status(mock_dependencies_for_my_workflows):
             "instances": [],
             "selected_created_at": date.today().isoformat(),
             "selected_status": "active",  # Reflects the default used
-            "workflow_statuses": [s.value for s in WorkflowStatus]
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": None  # Added
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_my_workflows_with_definition_id_filter(mock_dependencies_for_my_workflows):
+    client = TestClient(app)
+    mock_service, mock_renderer = mock_dependencies_for_my_workflows
+
+    test_definition_id = "test_def_id_123"
+
+    response = client.get(f"/my-workflows?definition_id={test_definition_id}")
+    assert response.status_code == 200
+
+    mock_service.list_instances_for_user.assert_called_once_with(
+        user_id=mock_user.user_id,
+        created_at_date=date.today(), # Default when not provided
+        status=WorkflowStatus.active, # Default when not provided
+        definition_id=test_definition_id
+    )
+    mock_renderer.render.assert_called_once_with(
+        "my_workflows.html",
+        ANY,
+        {
+            "instances": [],
+            "selected_created_at": date.today().isoformat(),
+            "selected_status": "active",
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": test_definition_id
+        }
+    )
+
+@pytest.mark.asyncio
+async def test_my_workflows_with_definition_id_and_other_filters(mock_dependencies_for_my_workflows):
+    client = TestClient(app)
+    mock_service, mock_renderer = mock_dependencies_for_my_workflows
+
+    test_definition_id = "test_def_id_456"
+    test_date_str = "2023-03-25"
+    test_date_obj = date(2023, 3, 25)
+    test_status = WorkflowStatus.completed
+    test_status_str = "completed"
+
+    response = client.get(f"/my-workflows?definition_id={test_definition_id}&created_at={test_date_str}&status={test_status_str}")
+    assert response.status_code == 200
+
+    mock_service.list_instances_for_user.assert_called_once_with(
+        user_id=mock_user.user_id,
+        created_at_date=test_date_obj,
+        status=test_status,
+        definition_id=test_definition_id
+    )
+    mock_renderer.render.assert_called_once_with(
+        "my_workflows.html",
+        ANY,
+        {
+            "instances": [],
+            "selected_created_at": test_date_str,
+            "selected_status": test_status_str,
+            "workflow_statuses": [s.value for s in WorkflowStatus],
+            "selected_definition_id": test_definition_id
         }
     )


### PR DESCRIPTION
This commit introduces a new feature allowing you to filter workflow instances directly from the workflow definitions page.

Key changes:

-   **Workflow Definitions Page (`app/templates/workflow_definitions.html`):**
    -   Added a "View Instances" button to each workflow definition.
    -   This button links to the "My Workflows" page (`/my-workflows`) with a
        `definition_id` query parameter.

-   **User Workflows Router (`app/routers/user_workflows.py`):**
    -   The `list_user_workflows` endpoint now accepts an optional
        `definition_id` query parameter.
    -   This `definition_id` is passed to the service layer for filtering.
    -   The active `definition_id` is also passed to the template context.

-   **My Workflows Page (`app/templates/my_workflows.html`):**
    -   Displays a message indicating if the instances are currently filtered
        by a specific workflow definition ID.
    -   Includes a "Clear filter" link to remove the definition filter.

-   **Service Layer (`app/services.py`):**
    -   The `WorkflowService.list_instances_for_user` method now accepts an
        optional `definition_id` parameter and passes it to the repository.

-   **Repository Layer (`app/repository.py`):**
    -   The `WorkflowInstanceRepository` ABC and its implementations
        (`PostgreSQLWorkflowRepository`, `InMemoryWorkflowRepository`) have
        been updated.
    -   The `list_workflow_instances_by_user` method in each now accepts an
        optional `definition_id` and filters instances accordingly.
        -   For PostgreSQL, an SQL `WHERE` clause is added.
        -   For InMemory, list comprehension is used for filtering.

-   **Tests:**
    -   Added new tests and updated existing ones in
        `test_api_endpoints.py`, `test_services.py`, and
        `test_repository.py` to cover the new filtering functionality.
    -   This includes tests for the API endpoint, service logic, and
        both repository implementations (unit and integration tests).