### PR TITLE
Fix: Use https in share links by trusting X-Forwarded-Proto

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,12 +5,15 @@ import sys
 # Add the project root to sys.path to ensure 'app' module can be found
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from fastapi import FastAPI
+from starlette.middleware.forwarded import ForwardedMiddleware
 from fastapi.staticfiles import StaticFiles
 from app.routers import root, workflow_definitions, workflow_instances, tasks, auth, user_workflows, api, share
 
 app = FastAPI(
     redirect_slashes=False,
 )
+
+app.add_middleware(ForwardedMiddleware, forwarded_allow_ips='*', forwarded_count=1)
 
 # Mount static files
 app.mount("/static", StaticFiles(directory="app/templates"), name="static")


### PR DESCRIPTION
The share link generated on the workflow instance page was using http instead of https when the application is deployed behind a reverse proxy that terminates TLS.

This commit addresses the issue by adding `ForwardedMiddleware` to the FastAPI application. This middleware allows the application to correctly determine the request scheme (http or https) by looking at the `X-Forwarded-Proto` header provided by the reverse proxy.

The middleware is configured to trust all upstream IPs and expects one layer of proxy (`forwarded_allow_ips='*'`, `forwarded_count=1`).

No changes were needed in the template, as `request.url_for()` will now correctly generate links with the appropriate scheme.