### PR TITLE
The input message does not violate any of the rules, so it can be out…

### DIFF
--- a/app/tests/test_repository.py
+++ b/app/tests/test_repository.py
@@ -15,33 +15,14 @@ from app.db_models.task_definition import TaskDefinition as TaskDefinitionORM
 from app.db_models.workflow import WorkflowDefinition as WorkflowDefinitionORM # Already imported as part of db_models but good to be explicit for ORM usage
 
 from unittest.mock import MagicMock
-# Setup for PostgreSQL database for testing
-# Use environment variables or a test-specific configuration for the database connection
+# Setup for SQLite database for testing
 from datetime import datetime  # Added for mock ORM objects
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from app.config import DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME
 
-# Construct the test database URL, appending '_test' to the database name to avoid using the main DB
-TEST_DB_NAME = f"{DB_NAME}_test"
-# First connect to 'postgres' database to create the test database if it doesn't exist
-BASE_DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/postgres"
-base_engine = create_engine(BASE_DATABASE_URL, echo=True)
-with base_engine.connect() as conn:
-    conn.execute(text("COMMIT"))
-    # Check if the test database exists, create if it doesn't
-    result = conn.execute(text(f"SELECT 1 FROM pg_database WHERE datname = '{TEST_DB_NAME}'"))
-    if not result.fetchone():
-        conn.execute(text(f"CREATE DATABASE {TEST_DB_NAME}"))
-        print(f"Created test database: {TEST_DB_NAME}")
-    else:
-        print(f"Test database {TEST_DB_NAME} already exists")
-
-base_engine.dispose()
-
-# Now connect to the test database
-SQLALCHEMY_DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{TEST_DB_NAME}"
-engine = create_engine(SQLALCHEMY_DATABASE_URL, echo=True)
+# Use in-memory SQLite database for tests
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, echo=True, connect_args={"check_same_thread": False}) # Added connect_args for SQLite
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 


### PR DESCRIPTION
…putted as is:

Switch tests to use SQLite instead of PostgreSQL.

This commit modifies the test setup to use an in-memory SQLite database for running automated tests, significantly speeding up test execution and removing the dependency on a running PostgreSQL server for tests.

Key changes:
- Modified `app/tests/test_repository.py` to use SQLite, with all tests passing.
- Updated `app/tests/conftest.py` to provide a robust SQLite setup for all test files, including those using FastAPI's TestClient.
- Ensured that `app/tests/test_api_endpoints.py` now runs against SQLite. Existing test failures in this file are related to assertions or test logic rather than database infrastructure.
- The main application database configuration (`app/config.py`, `app/database.py`) remains unchanged, still defaulting to PostgreSQL for development/production.

This change helps simplify the testing environment and improves developer experience.